### PR TITLE
[QContextMenu] Fix trigger hover, add click target checking

### DIFF
--- a/src/qComponents/QContextMenu/src/QContextMenu.vue
+++ b/src/qComponents/QContextMenu/src/QContextMenu.vue
@@ -166,9 +166,7 @@ export default defineComponent({
     };
 
     const handleTriggerClick = (e: MouseEvent): void => {
-      const target = e.target as HTMLElement;
-
-      if (reference.value === target) return;
+      if (reference.value === e.target) return;
       if (isContextMenuShown.value) {
         closePopper();
         return;

--- a/src/qComponents/QContextMenu/src/QContextMenu.vue
+++ b/src/qComponents/QContextMenu/src/QContextMenu.vue
@@ -165,7 +165,10 @@ export default defineComponent({
       popperJS.value = null;
     };
 
-    const handleTriggerClick = (): void => {
+    const handleTriggerClick = (e: MouseEvent): void => {
+      const target = e.target as HTMLElement;
+
+      if (reference.value === target) return;
       if (isContextMenuShown.value) {
         closePopper();
         return;

--- a/src/qComponents/QContextMenu/src/q-context-menu.scss
+++ b/src/qComponents/QContextMenu/src/q-context-menu.scss
@@ -60,6 +60,7 @@
   &-trigger {
     display: inline-block;
     cursor: pointer;
+    border-radius: 100%;
 
     &__button {
       display: block;
@@ -70,13 +71,13 @@
       color: var(--color-primary-blue);
       background-color: transparent;
       border: none;
+      border-radius: 100%;
       outline: none;
 
       &:hover,
       &[data-focus-visible-added] {
         color: var(--color-primary-black);
         background-color: rgba(var(--color-rgb-gray), 0.16);
-        border-radius: 100%;
       }
     }
   }

--- a/src/qComponents/QContextMenu/src/q-context-menu.scss
+++ b/src/qComponents/QContextMenu/src/q-context-menu.scss
@@ -59,8 +59,6 @@
 
   &-trigger {
     display: inline-block;
-    cursor: pointer;
-    border-radius: 100%;
 
     &__button {
       display: block;
@@ -69,6 +67,7 @@
       padding: 0;
       font-size: 24px;
       color: var(--color-primary-blue);
+      cursor: pointer;
       background-color: transparent;
       border: none;
       border-radius: 100%;

--- a/src/qComponents/QContextMenu/src/types.ts
+++ b/src/qComponents/QContextMenu/src/types.ts
@@ -23,7 +23,7 @@ export interface QContextMenuInstance {
   contextMenu: Ref<Nullable<HTMLElement>>;
   zIndex: Ref<number>;
   isContextMenuShown: Ref<boolean>;
-  handleTriggerClick: () => void;
+  handleTriggerClick: (e: MouseEvent) => void;
   handleItemClick: (actionName: string) => void;
   setItemRef: (el: HTMLElement) => void;
   afterLeave: () => void;


### PR DESCRIPTION
Cursor pointer removed from trigger
Event target checking added into trigger click-handler, handler now works only of event target is a child of trigger