### PR TITLE
[QCollapseItem] Fix focus-visible

### DIFF
--- a/src/qComponents/QCascader/src/QCascaderRow/q-cascader-row.scss
+++ b/src/qComponents/QCascader/src/QCascaderRow/q-cascader-row.scss
@@ -15,12 +15,14 @@
   }
 
   &:not(.q-cascader-row_disabled) {
+    &:focus {
+      outline: none;
+    }
+
     &:hover,
-    &:focus,
     &.focus-visible {
       color: var(--color-primary-black);
       background-color: var(--color-tertiary-gray);
-      outline: none;
     }
   }
 

--- a/src/qComponents/QCollapseItem/src/q-collapse-item.scss
+++ b/src/qComponents/QCollapseItem/src/q-collapse-item.scss
@@ -22,8 +22,16 @@
       border-radius: var(--border-radius-base) var(--border-radius-base) 0 0;
     }
 
-    &:focus,
+    &:focus {
+      outline: none;
+    }
+
+    &.focus-visible,
     &:hover {
+      background-color: var(--color-tertiary-gray);
+    }
+
+    &:focus-visible {
       background-color: var(--color-tertiary-gray);
     }
   }

--- a/src/qComponents/QCollapseItem/src/q-collapse-item.scss
+++ b/src/qComponents/QCollapseItem/src/q-collapse-item.scss
@@ -26,12 +26,8 @@
       outline: none;
     }
 
-    &.focus-visible,
-    &:hover {
-      background-color: var(--color-tertiary-gray);
-    }
-
-    &:focus-visible {
+    &:hover,
+    &.focus-visible {
       background-color: var(--color-tertiary-gray);
     }
   }

--- a/src/qComponents/QInput/src/q-input.scss
+++ b/src/qComponents/QInput/src/q-input.scss
@@ -65,9 +65,12 @@
       height: 0;
     }
 
+    &:focus {
+      outline: none;
+    }
+
     &.focus-visible {
       background-color: var(--field-background-color-focus);
-      outline: none;
       box-shadow: var(--field-box-shadow-focus);
     }
 
@@ -167,8 +170,8 @@
         font-family: 'qicon';
       }
 
-      &.focus-visible,
-      &:hover {
+      &:hover,
+      &.focus-visible {
         color: var(--field-icon-color-hover);
       }
     }

--- a/src/qComponents/QTag/src/q-tag.scss
+++ b/src/qComponents/QTag/src/q-tag.scss
@@ -40,10 +40,13 @@
     background-color: transparent;
     border: none;
 
-    &.focus-visible,
-    &:hover {
-      color: var(--color-primary-black);
+    &:focus {
       outline: none;
+    }
+
+    &:hover,
+    &.focus-visible {
+      color: var(--color-primary-black);
     }
   }
 }


### PR DESCRIPTION
Remove outline in firefox
Use focus-visible polyfill
Show grey background only if focus-visible (not focus)