### PR TITLE
Fix storybook console warnings in docs

### DIFF
--- a/stories/core/icons.stories.mdx
+++ b/stories/core/icons.stories.mdx
@@ -1,6 +1,6 @@
 import {
   Meta,
-  Preview,
+  Canvas,
   Story,
   ArgsTable,
   IconGallery,
@@ -58,7 +58,7 @@ export const Template = args => ({
   `
 });
 
-<Preview>
+<Canvas>
   <Story
     name="Playground"
     args={{
@@ -69,6 +69,6 @@ export const Template = args => ({
   >
     {Template.bind({})}
   </Story>
-</Preview>
+</Canvas>
 
 <ArgsTable story="Playground" />

--- a/stories/plugins/QProgressIndicatior/QProgressIndicatior.stories.mdx
+++ b/stories/plugins/QProgressIndicatior/QProgressIndicatior.stories.mdx
@@ -1,13 +1,13 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs';
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
 import { QProgressIndicatiorStory } from './Template';
 
 <Meta title="Plugins/QProgressIndicatior" />
 
 # QProgressIndicatior
 
-<Preview>
+<Canvas>
   <Story name="Default">{QProgressIndicatiorStory.bind({})}</Story>
-</Preview>
+</Canvas>
 
 ## Plugin options
 


### PR DESCRIPTION
1. replace Preview to Canvas in icons.stories and QProgressIndicator.stories 
2. Nothing to fix to remove warning about "storyFn" because it never used in project and warning triggered automatically by Docs tab (will be fixed in version 6.4 (perhaps). 

Quote from Storybook repo: 
> NOTE: If you're using @storybook/addon-docs, this deprecation warning is triggered by the Docs tab in 6.1. It's safe to ignore and we will be providing a proper fix in a future release. You can track the issue at https://github.com/storybookjs/storybook/issues/13074