### PR TITLE
fix: handleDocumentFocus in qDialog and qDrawer

### DIFF
--- a/src/qComponents/QDialog/src/QDialogContainer/index.vue
+++ b/src/qComponents/QDialog/src/QDialogContainer/index.vue
@@ -147,8 +147,9 @@ export default defineComponent({
       document.activeElement as Nullable<HTMLElement>;
 
     const handleDocumentFocus = (event: FocusEvent): void => {
-      if (dialog.value?.contains(event.target as HTMLElement)) {
-        dialog.value.focus();
+      const dialogValue = dialog.value;
+      if (dialogValue && !dialogValue.contains(event.target as HTMLElement)) {
+        dialogValue.focus();
       }
     };
 

--- a/src/qComponents/QDrawer/src/QDrawerContainer/index.vue
+++ b/src/qComponents/QDrawer/src/QDrawerContainer/index.vue
@@ -172,8 +172,9 @@ export default defineComponent({
       document.activeElement as Nullable<HTMLElement>;
 
     const handleDocumentFocus = (event: FocusEvent): void => {
-      if (drawer.value?.contains(event.target as HTMLElement)) {
-        drawer.value.focus();
+      const drawerValue = drawer.value;
+      if (drawerValue && !drawerValue.contains(event.target as HTMLElement)) {
+        drawerValue.focus();
       }
     };
 


### PR DESCRIPTION
Условия, при котором **qDrawer** и **qDialog** должны быть сфокусированы, описаны неверно, по этой причине клик по инпуту внутри **qDialog** или **qDrawer** вызывал выполнение этого условия и, как следствие, потерю фокуса у инпута (при клике на инпут выполнялось `dialog.value.focus()` или `drawer.value.focus()`соответственно ) 