### PR TITLE
fix(QDatepicker): max date calculation in range mode

### DIFF
--- a/src/qComponents/QDatePicker/src/commonTypes.ts
+++ b/src/qComponents/QDatePicker/src/commonTypes.ts
@@ -12,6 +12,8 @@ type RangePickValue = {
   rangeState: RangeState;
 };
 
+type RangeType = 'daterange' | 'monthrange' | 'yearrange';
+
 interface DateCellModel {
   row: number;
   column: number;
@@ -40,5 +42,6 @@ export {
   RangeState,
   DateCellModel,
   TableProps,
-  TablePropSelectionMode
+  TablePropSelectionMode,
+  RangeType
 };

--- a/src/qComponents/QDatePicker/src/panel/DateRange/DateRange.vue
+++ b/src/qComponents/QDatePicker/src/panel/DateRange/DateRange.vue
@@ -271,7 +271,8 @@ export default defineComponent({
     const handleRangePick = (val: RangePickValue, close = true): void => {
       const { maxDate, minDate, rangeState } = getRangeChangedState(
         val,
-        state.rangeState
+        state.rangeState,
+        'daterange'
       );
       state.maxDate = maxDate;
       state.minDate = minDate;

--- a/src/qComponents/QDatePicker/src/panel/MonthRange/MonthRange.vue
+++ b/src/qComponents/QDatePicker/src/panel/MonthRange/MonthRange.vue
@@ -204,7 +204,8 @@ export default defineComponent({
     const handleRangePick = (val: RangePickValue, close = true): void => {
       const { maxDate, minDate, rangeState } = getRangeChangedState(
         val,
-        state.rangeState
+        state.rangeState,
+        'monthrange'
       );
       state.maxDate = maxDate;
       state.minDate = minDate;

--- a/src/qComponents/QDatePicker/src/panel/YearRange/YearRange.vue
+++ b/src/qComponents/QDatePicker/src/panel/YearRange/YearRange.vue
@@ -219,7 +219,8 @@ export default defineComponent({
     const handleRangePick = (val: RangePickValue, close = true): void => {
       const { maxDate, minDate, rangeState } = getRangeChangedState(
         val,
-        state.rangeState
+        state.rangeState,
+        'yearrange'
       );
       state.maxDate = maxDate;
       state.minDate = minDate;

--- a/src/qComponents/QDatePicker/src/panel/composition.ts
+++ b/src/qComponents/QDatePicker/src/panel/composition.ts
@@ -2,6 +2,8 @@ import {
   addYears,
   endOfDay,
   endOfDecade,
+  endOfMonth,
+  endOfYear,
   startOfDecade,
   subYears
 } from 'date-fns';
@@ -10,7 +12,7 @@ import { isDate } from 'lodash-es';
 import { getConfig } from '@/qComponents/config';
 import type { Nullable } from '#/helpers';
 
-import type { RangePickValue, RangeState } from '../commonTypes';
+import type { RangePickValue, RangeState, RangeType } from '../commonTypes';
 import {
   CELLS_COUNT_IN_YEAR_RANGE,
   LEFT_PERIOD_PANEL_START_INDEX,
@@ -122,16 +124,37 @@ const getPeriodNextNodeIndex = (
 
 const getRangeChangedState = (
   newValue: RangePickValue,
-  currentRangeState: RangeState
+  currentRangeState: RangeState,
+  type: RangeType
 ): {
   maxDate: Nullable<Date>;
   minDate: Nullable<Date>;
   rangeState: RangeState;
-} => ({
-  maxDate: newValue.maxDate ? endOfDay(newValue.maxDate) : newValue.maxDate,
-  minDate: newValue.minDate,
-  rangeState: newValue.rangeState ? newValue.rangeState : currentRangeState
-});
+} => {
+  let maxDate = null;
+
+  if (newValue.maxDate) {
+    switch (type) {
+      case 'yearrange':
+        maxDate = endOfYear(newValue.maxDate);
+        break;
+      case 'monthrange':
+        maxDate = endOfMonth(newValue.maxDate);
+        break;
+      case 'daterange':
+        maxDate = endOfDay(newValue.maxDate);
+        break;
+      default:
+        maxDate = newValue.maxDate;
+    }
+  }
+
+  return {
+    maxDate: maxDate ?? newValue.maxDate,
+    minDate: newValue.minDate,
+    rangeState: newValue.rangeState ? newValue.rangeState : currentRangeState
+  };
+};
 
 export {
   leftYearComposable,

--- a/src/qComponents/QDatePicker/src/panel/composition.ts
+++ b/src/qComponents/QDatePicker/src/panel/composition.ts
@@ -150,7 +150,7 @@ const getRangeChangedState = (
   }
 
   return {
-    maxDate: maxDate ?? newValue.maxDate,
+    maxDate,
     minDate: newValue.minDate,
     rangeState: newValue.rangeState ? newValue.rangeState : currentRangeState
   };


### PR DESCRIPTION
Фикс конечной даты в режимах диапазонов: 

- `daterange` - до 23.59.59 выбранного дня
- `monthrange` -  до 23.59.59 последнего дня выбранного месяца
- `yearrange` - до 23.59.59 последнего дня выбранного года