### PR TITLE
docs: QDatepicker

### DIFF
--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -6,6 +6,6 @@ export default create({
   base: 'light',
 
   brandTitle: 'QUI-MAX',
-  brandUrl: 'https://qvant-lab.github.io/qui-max/',
+  brandUrl: 'https://qui-max.netlify.app',
   brandImage: logo
 });

--- a/src/qComponents/QDatePicker/src/QDatePicker.vue
+++ b/src/qComponents/QDatePicker/src/QDatePicker.vue
@@ -6,6 +6,7 @@
   >
     <div
       v-if="!isRanged"
+      class="q-date-picker__wrapper"
       @mouseenter="handleMouseEnter"
       @mouseleave="state.showCloseIcon = false"
     >

--- a/src/qComponents/QDatePicker/src/q-date-picker.scss
+++ b/src/qComponents/QDatePicker/src/q-date-picker.scss
@@ -52,6 +52,7 @@
 
       &:hover {
         background-color: var(--color-tertiary-gray);
+        box-shadow: var(--field-box-shadow-hover);
       }
 
       .q-date-picker__input {
@@ -117,6 +118,10 @@
         cursor: not-allowed;
         background-color: var(--color-tertiary-gray);
         box-shadow: var(--box-shadow-pressed);
+
+        &:hover {
+          box-shadow: var(--box-shadow-pressed);
+        }
 
         .q-date-picker__range-separator,
         .q-date-picker__input {

--- a/src/qComponents/QDatePicker/src/q-date-picker.scss
+++ b/src/qComponents/QDatePicker/src/q-date-picker.scss
@@ -52,7 +52,6 @@
 
       &:hover {
         background-color: var(--color-tertiary-gray);
-        box-shadow: var(--field-box-shadow-hover);
       }
 
       .q-date-picker__input {

--- a/src/qComponents/QDatePicker/src/q-date-picker.scss
+++ b/src/qComponents/QDatePicker/src/q-date-picker.scss
@@ -15,6 +15,10 @@
     4px 4px 8px rgb(var(--color-rgb-blue) / 40%),
     -4px -4px 8px rgb(var(--color-rgb-white) / 80%);
 
+  &__wrapper {
+    height: 40px;
+  }
+
   &__input {
     position: relative;
     display: inline-block;

--- a/src/qComponents/QDatePicker/src/tables/DateTable/date-table.scss
+++ b/src/qComponents/QDatePicker/src/tables/DateTable/date-table.scss
@@ -82,7 +82,7 @@
         color: var(--color-primary);
       }
 
-      &.cell_current,
+      &.cell_current:not(.cell_disabled),
       &.cell_in-range:not(.cell_prev-month),
       &.cell_in-range:not(.cell_next-month) {
         color: var(--color-tertiary-white);

--- a/src/qComponents/QDatePicker/src/types.ts
+++ b/src/qComponents/QDatePicker/src/types.ts
@@ -11,7 +11,9 @@ import type YearRangePanel from './panel/YearRange/YearRange.vue';
 
 import type { DatePanelInstance } from './panel/Date/types';
 
-type QDatePickerPropModelValue = Nullable<string | Date | string[] | Date[]>;
+type QDatePickerPropModelValue = Nullable<
+  string | Date | [string, string] | [Date, Date]
+>;
 type QDatePickerPropOutputFormat = 'date' | 'iso';
 type QDatePickerPropType =
   | 'date'

--- a/stories/components/QDatePicker.stories.ts
+++ b/stories/components/QDatePicker.stories.ts
@@ -164,15 +164,15 @@ Year.args = {
 Shortcuts.args = {
   shortcuts: [
     {
-      text: 'Сегодня',
+      text: 'Today',
       value: now
     },
     {
-      text: 'Вчера',
+      text: 'Yesterday',
       value: startOfYesterday()
     },
     {
-      text: 'Неделю назад',
+      text: 'A week ago',
       value: subWeeks(now, 1)
     }
   ]

--- a/vuepress-docs/docs/.vuepress/config.ts
+++ b/vuepress-docs/docs/.vuepress/config.ts
@@ -26,7 +26,8 @@ export default defineUserConfig<DefaultThemeOptions, ViteBundlerOptions>({
           '/components/QCheckboxGroup.md',
           '/components/QCollapse.md',
           '/components/QColorpicker.md',
-          '/components/QContextMenu.md'
+          '/components/QContextMenu.md',
+          '/components/QDatepicker.md'
         ]
       },
       // NavbarGroup
@@ -52,7 +53,8 @@ export default defineUserConfig<DefaultThemeOptions, ViteBundlerOptions>({
             '/components/QCheckboxGroup.md',
             '/components/QCollapse.md',
             '/components/QColorpicker.md',
-            '/components/QContextMenu.md'
+            '/components/QContextMenu.md',
+            '/components/QDatepicker.md'
           ]
         }
       ],

--- a/vuepress-docs/docs/.vuepress/public/QDatepicker/disabled.html
+++ b/vuepress-docs/docs/.vuepress/public/QDatepicker/disabled.html
@@ -1,0 +1,53 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!-- import CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@qvant/qui-max/dist/style.css"
+    />
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="block">
+        <q-row>
+          <q-col cols="6">
+            <q-date-picker v-model="value" disabled />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col cols="6">
+            <q-date-picker v-model="valueRanged" type="daterange" disabled />
+          </q-col>
+        </q-row>
+      </div>
+    </div>
+  </body>
+  <!-- import Vue before Qui -->
+  <script src="https://unpkg.com/vue@latest"></script>
+  <!-- import JavaScript -->
+  <script src="https://unpkg.com/@qvant/qui-max@latest"></script>
+  <script>
+    const app = Vue.createApp({
+      setup() {
+        const value = Vue.ref(new Date());
+        const valueRanged = Vue.ref([
+          new Date(Date.now() - 3600 * 24 * 1000),
+          new Date()
+        ]);
+
+        return { value, valueRanged };
+      }
+    });
+
+    app.use(QuiMax.default);
+    app.mount('#app');
+  </script>
+  <style>
+    .block {
+      margin: 20px;
+    }
+  </style>
+</html>

--- a/vuepress-docs/docs/.vuepress/public/QDatepicker/disabledValues.html
+++ b/vuepress-docs/docs/.vuepress/public/QDatepicker/disabledValues.html
@@ -1,0 +1,64 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!-- import CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@qvant/qui-max/dist/style.css"
+    />
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="block">
+        <q-row>
+          <q-col cols="6">
+            <p>disable due today</p>
+            <q-date-picker v-model="value" :disabled-values="disabledValues" />
+          </q-col>
+          <q-col cols="6">
+            <p>disable range - tree days in two days from today</p>
+            <q-date-picker
+              v-model="valueRanges"
+              :disabled-values="disabledValuesRanges"
+            />
+          </q-col>
+        </q-row>
+      </div>
+    </div>
+  </body>
+  <!-- import Vue before Qui -->
+  <script src="https://unpkg.com/vue@latest"></script>
+  <!-- import JavaScript -->
+  <script src="https://unpkg.com/@qvant/qui-max@latest"></script>
+  <script>
+    const app = Vue.createApp({
+      setup() {
+        const value = Vue.ref(null);
+        const valueRanges = Vue.ref(null);
+        const disabledValues = {
+          to: new Date()
+        };
+
+        const disabledValuesRanges = {
+          ranges: [
+            {
+              start: new Date(Date.now() + 48 * 3600 * 1000),
+              end: new Date(Date.now() + 120 * 3600 * 1000)
+            }
+          ]
+        };
+
+        return { value, valueRanges, disabledValues, disabledValuesRanges };
+      }
+    });
+
+    app.use(QuiMax.default);
+    app.mount('#app');
+  </script>
+  <style>
+    .block {
+      margin: 20px;
+    }
+  </style>
+</html>

--- a/vuepress-docs/docs/.vuepress/public/QDatepicker/firstDayOfWeek.html
+++ b/vuepress-docs/docs/.vuepress/public/QDatepicker/firstDayOfWeek.html
@@ -1,0 +1,44 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!-- import CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@qvant/qui-max/dist/style.css"
+    />
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="block">
+        <q-row>
+          <q-col cols="6">
+            <p>Start week with Monday</p>
+            <q-date-picker v-model="value" :first-day-of-week="1" />
+          </q-col>
+        </q-row>
+      </div>
+    </div>
+  </body>
+  <!-- import Vue before Qui -->
+  <script src="https://unpkg.com/vue@latest"></script>
+  <!-- import JavaScript -->
+  <script src="https://unpkg.com/@qvant/qui-max@latest"></script>
+  <script>
+    const app = Vue.createApp({
+      setup() {
+        const value = Vue.ref(new Date());
+
+        return { value };
+      }
+    });
+
+    app.use(QuiMax.default);
+    app.mount('#app');
+  </script>
+  <style>
+    .block {
+      margin: 20px;
+    }
+  </style>
+</html>

--- a/vuepress-docs/docs/.vuepress/public/QDatepicker/format.html
+++ b/vuepress-docs/docs/.vuepress/public/QDatepicker/format.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!-- import CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@qvant/qui-max/dist/style.css"
+    />
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="block">
+        <q-row>
+          <q-col cols="6">
+            <q-date-picker v-model="value" format="yyyy/MM/dd" />
+          </q-col>
+        </q-row>
+      </div>
+    </div>
+  </body>
+  <!-- import Vue before Qui -->
+  <script src="https://unpkg.com/vue@latest"></script>
+  <!-- import JavaScript -->
+  <script src="https://unpkg.com/@qvant/qui-max@latest"></script>
+  <script>
+    const app = Vue.createApp({
+      setup() {
+        const value = Vue.ref(new Date());
+
+        return { value };
+      }
+    });
+
+    app.use(QuiMax.default);
+    app.mount('#app');
+  </script>
+  <style>
+    .block {
+      margin: 20px;
+    }
+  </style>
+</html>

--- a/vuepress-docs/docs/.vuepress/public/QDatepicker/main.html
+++ b/vuepress-docs/docs/.vuepress/public/QDatepicker/main.html
@@ -1,0 +1,111 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!-- import CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@qvant/qui-max/dist/style.css"
+    />
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="block">
+        <q-row>
+          <q-col cols="6">
+            <p>Type: <b>date</b></p>
+            <q-date-picker v-model="value" />
+          </q-col>
+          <q-col cols="6">
+            <p>Type: <b>month</b></p>
+            <q-date-picker v-model="valueMonth" type="month" />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col cols="6">
+            <p>Type: <b>year</b></p>
+            <q-date-picker v-model="valueYear" type="year" />
+          </q-col>
+          <q-col cols="6">
+            <p>with <b>shortcuts</b></p>
+            <q-date-picker v-model="valueShortcuts" :shortcuts="shortcuts" />
+          </q-col>
+        </q-row>
+        <br />
+        <br />
+        <q-row>
+          <q-col cols="6" offset="3">
+            <p>Type: <b>daterange</b></p>
+            <q-date-picker v-model="valueDateRanged" type="daterange" />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col cols="6" offset="3">
+            <p>Type: <b>monthrange</b></p>
+            <q-date-picker v-model="valueMonthRanged" type="monthrange" />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col cols="6" offset="3">
+            <p>Type: <b>yearrange</b></p>
+            <q-date-picker v-model="valueYearRanged" type="yearrange" />
+          </q-col>
+        </q-row>
+      </div>
+    </div>
+  </body>
+  <!-- import Vue before Qui -->
+  <script src="https://unpkg.com/vue@latest"></script>
+  <!-- import JavaScript -->
+  <script src="https://unpkg.com/@qvant/qui-max@latest"></script>
+  <script>
+    const app = Vue.createApp({
+      setup() {
+        const value = Vue.ref(null);
+        const valueMonth = Vue.ref(null);
+        const valueYear = Vue.ref(null);
+        const valueShortcuts = Vue.ref(null);
+        const valueDateRanged = Vue.ref(null);
+        const valueMonthRanged = Vue.ref(null);
+        const valueYearRanged = Vue.ref(null);
+
+        const shortcuts = [
+          {
+            text: 'Today',
+            value: new Date()
+          },
+          {
+            text: 'Yesterday',
+            value: new Date(Date.now() - 3600 * 24 * 1000)
+          },
+          {
+            text: 'A week ago',
+            value: new Date(Date.now() - 3600 * 24 * 1000 * 7)
+          }
+        ];
+
+        return {
+          value,
+          valueMonth,
+          valueYear,
+          valueShortcuts,
+          shortcuts,
+          valueDateRanged,
+          valueMonthRanged,
+          valueYearRanged
+        };
+      }
+    });
+
+    app.use(QuiMax.default);
+    app.mount('#app');
+  </script>
+  <style>
+    .block {
+      margin: 20px;
+    }
+  </style>
+</html>

--- a/vuepress-docs/docs/.vuepress/public/QDatepicker/mobile.html
+++ b/vuepress-docs/docs/.vuepress/public/QDatepicker/mobile.html
@@ -1,0 +1,111 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!-- import CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@qvant/qui-max/dist/style.css"
+    />
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="block">
+        <q-row>
+          <q-col cols="6">
+            <p>Type: <b>date</b></p>
+            <q-date-picker v-model="value" />
+          </q-col>
+          <q-col cols="6">
+            <p>Type: <b>month</b></p>
+            <q-date-picker v-model="valueMonth" type="month" />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col cols="6">
+            <p>Type: <b>year</b></p>
+            <q-date-picker v-model="valueYear" type="year" />
+          </q-col>
+          <q-col cols="6">
+            <p>with <b>shortcuts</b></p>
+            <q-date-picker v-model="valueShortcuts" :shortcuts="shortcuts" />
+          </q-col>
+        </q-row>
+        <br />
+        <br />
+        <q-row>
+          <q-col>
+            <p>Type: <b>daterange</b></p>
+            <q-date-picker v-model="valueDateRanged" type="daterange" />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col>
+            <p>Type: <b>monthrange</b></p>
+            <q-date-picker v-model="valueMonthRanged" type="monthrange" />
+          </q-col>
+        </q-row>
+        <br />
+        <q-row>
+          <q-col>
+            <p>Type: <b>yearrange</b></p>
+            <q-date-picker v-model="valueYearRanged" type="yearrange" />
+          </q-col>
+        </q-row>
+      </div>
+    </div>
+  </body>
+  <!-- import Vue before Qui -->
+  <script src="https://unpkg.com/vue@latest"></script>
+  <!-- import JavaScript -->
+  <script src="https://unpkg.com/@qvant/qui-max@latest"></script>
+  <script>
+    const app = Vue.createApp({
+      setup() {
+        const value = Vue.ref(null);
+        const valueMonth = Vue.ref(null);
+        const valueYear = Vue.ref(null);
+        const valueShortcuts = Vue.ref(null);
+        const valueDateRanged = Vue.ref(null);
+        const valueMonthRanged = Vue.ref(null);
+        const valueYearRanged = Vue.ref(null);
+
+        const shortcuts = [
+          {
+            text: 'Today',
+            value: new Date()
+          },
+          {
+            text: 'Yesterday',
+            value: new Date(Date.now() - 3600 * 24 * 1000)
+          },
+          {
+            text: 'A week ago',
+            value: new Date(Date.now() - 3600 * 24 * 1000 * 7)
+          }
+        ];
+
+        return {
+          value,
+          valueMonth,
+          valueYear,
+          valueShortcuts,
+          shortcuts,
+          valueDateRanged,
+          valueMonthRanged,
+          valueYearRanged
+        };
+      }
+    });
+
+    app.use(QuiMax.default);
+    app.mount('#app');
+  </script>
+  <style>
+    .block {
+      margin: 20px;
+    }
+  </style>
+</html>

--- a/vuepress-docs/docs/components/QDatepicker.md
+++ b/vuepress-docs/docs/components/QDatepicker.md
@@ -1,0 +1,160 @@
+# QDatepicker
+
+To select or input a date. We support default type `Date` and `ISO`.
+
+## When to use
+
+- When you need to pick a date as a value.
+
+## Example
+
+Default view (Desktop):
+- viewport width > 768px
+
+<iframe style="width: 769px; height: 750px" scrolling="no" frameborder="no" src="/QDatepicker/main.html"></iframe>
+
+Default view (Mobile):
+- if width < 769px QDatepicker opens on popup
+- Example for iPhone SE's dimensions: (375 x 667)px
+
+<iframe style="height: 667px; width: 375px" scrolling="no" frameborder="no" src="/QDatepicker/mobile.html"></iframe>
+
+Using in template:
+
+```vue
+<q-date-picker v-model="value" />
+```
+
+Using in component instance:
+
+```js
+export default defineComponent({
+  setup() {
+    const value = Vue.ref(null);
+
+    return { value };
+  }
+})
+```
+
+## Props
+
+### modelValue
+
+- Type: `Date | String | Array`
+- Default: `null`
+
+Binding value.
+
+`modelValue` depends on `type` prop. 
+- For type `date`, `week`, `month`, `year` it MUST be a single value - `String` (ISO) or `Date`.
+- For type `daterange`, `monthrange`, `yearrange` it MUST be an `Array` of `String`'s (ISO) or `Date`'s
+
+```ts
+// import type from lib
+import type { QDatePickerPropModelValue } from '@qvant/qui-max';
+
+// TS type
+type QDatePickerPropModelValue = Nullable<string | Date | string[] | Date[]>;
+```
+
+### type
+
+- Type: `'date' | 'week' | 'month' | 'year' | 'daterange' | 'monthrange' | 'yearrange'`
+- Default: `'date'`
+
+Defines the picker mode.
+
+```ts
+// import type from lib
+import type { QDatePickerPropType } from '@qvant/qui-max';
+
+// TS type
+type QDatePickerPropType =
+  | 'date'
+  | 'week'
+  | 'month'
+  | 'year'
+  | 'daterange'
+  | 'monthrange'
+  | 'yearrange';
+  ```
+
+<!-- prettier-ignore-start -->
+```vue {3}
+<q-date-picker
+  v-model="value"
+  type="date"
+/>
+```
+<!-- prettier-ignore-end -->
+
+See [example](./QDatepicker/#example) above.
+
+### format
+
+- Type `String`
+- Default: `dd MMMM yyyy`
+
+Sets custom date formatting in the input. We use `date-fns` formatting, so you should use their [config](https://date-fns.org/v2.28.0/docs/format)
+
+<!-- prettier-ignore-start -->
+```vue {3}
+<q-date-picker
+  v-model="value"
+  format="yyyy/MM/dd"
+/>
+```
+<!-- prettier-ignore-end -->
+
+<iframe style="height: 367px; width: 769px" scrolling="no" frameborder="no" src="/QDatepicker/format.html"></iframe>
+
+
+### outputFormat
+
+Defines output date format (what exactly will be as a `value`).
+
+There is only two options available: 
+- Type `'date' | 'iso'`
+- Default: `'date'`
+
+```vue {3}
+<q-date-picker
+  v-model="value"
+  output-format="iso"
+/>
+
+console.log(value) // 2022-02-15T21:00:00.000Z
+
+<q-date-picker
+  v-model="value"
+>
+
+console.log(value) // Wed Feb 16 2022 18:43:46 GMT+0300 (Moscow Standard Time)
+```
+
+### placeholder
+
+As native input placeholder. Use this prop for single types: `date`, `week`, `month`, `year`.
+
+```vue {3}
+<q-date-picker
+  v-model="value"
+  placeholder="Pick a date"
+/>
+```
+
+### startPlaceholder / endPlaceholder
+
+The ranged datepickers have two inputs, so `startPlaceholder` and `endPlaceholder` define their placeholders. Use this props for ranged types: `daterange`, `monthrange`, `yearrange`.
+
+```vue {3,4}
+<q-date-picker
+  v-model="value"
+  start-placeholder="from"
+  end-placeholder="to"
+/>
+```
+
+### shortcuts
+...

--- a/vuepress-docs/docs/components/QDatepicker.md
+++ b/vuepress-docs/docs/components/QDatepicker.md
@@ -137,6 +137,9 @@ console.log(value) // Wed Feb 16 2022 18:43:46 GMT+0300 (Moscow Standard Time)
 
 As native input placeholder. Use this prop for single types: `date`, `week`, `month`, `year`.
 
+- Type `String`
+- Default: `null`
+
 ```vue {3}
 <q-date-picker
   v-model="value"
@@ -148,6 +151,9 @@ As native input placeholder. Use this prop for single types: `date`, `week`, `mo
 
 The ranged datepickers have two inputs, so `startPlaceholder` and `endPlaceholder` define their placeholders. Use this props for ranged types: `daterange`, `monthrange`, `yearrange`.
 
+- Type `String`
+- Default: `null`
+
 ```vue {3,4}
 <q-date-picker
   v-model="value"
@@ -157,4 +163,98 @@ The ranged datepickers have two inputs, so `startPlaceholder` and `endPlaceholde
 ```
 
 ### shortcuts
-...
+
+Defines date shortcuts, set any date to be able to select it faster.
+
+- Type `Array`
+- Default `null`
+
+The `shortcuts` MUST be an `Array` of `Object`s, each object MUST contain:
+- `text` - shortcut's label (e.g `Today`, `Yestarday`, `A week ago`, etc.)
+- `value` - a shortcut's value as a `Date` 
+
+```ts
+// import type from lib
+import { QDatePickerPropShortcuts } from '@qvant/qui-max';
+
+// TS type
+type QDatePickerPropShortcuts = {
+  text: string;
+  value: Date;
+}[];
+```
+
+```vue {3}
+<q-date-picker
+  v-model="value"
+  :shortcuts="shortcuts"
+/>
+```
+
+```js
+export default defineComponent({
+  setup() {
+    const value = ref(null);
+    const shortcuts = [
+      {
+        text: 'Today',
+        value: new Date()
+      },
+      {
+        text: 'Yesterday',
+        value: new Date(Date.now() - 3600 * 24 * 1000)
+      },
+      {
+        text: 'A week ago',
+        value: new Date(Date.now() - 3600 * 24 * 1000 * 7)
+      }
+    ];
+
+    return { value, shortcuts };
+  }
+})
+```
+
+See [example](./QDatepicker/#example) above.
+
+### firstDayOfWeek
+
+Defines the first day of the week. Sunday by default.
+
+- Type: `0 | 1 | 2 | 3 | 4 | 5 | 6`
+- Default: `0`
+
+Each `number` correspondes a week day:
+- `0` - `monday`
+- `1` - `tuesday`
+- `2` - `wednesday` 
+- `3` - `thursday`
+- `4` - `friday`
+- `5` - `saturday`
+- `6` - `sunday`
+
+```vue {4}
+// start with monday
+<q-date-picker
+  v-model="value"
+  :first-day-of-week="1" 
+/>
+```
+
+<iframe style="height: 367px; width: 769px" scrolling="no" frameborder="no" src="/QDatepicker/firstDayOfWeek.html"></iframe>
+
+### disabled
+
+Whether QDatePicker is disabled.
+
+- Type: `Boolean`
+- Default: `false`
+
+<iframe style="height: 367px; width: 100%" scrolling="no" frameborder="no" src="/QDatepicker/disabled.html"></iframe>
+
+### name
+
+As native name for input
+
+- Type: `String`
+- Default: `''`

--- a/vuepress-docs/docs/components/QDatepicker.md
+++ b/vuepress-docs/docs/components/QDatepicker.md
@@ -250,7 +250,95 @@ Whether QDatePicker is disabled.
 - Type: `Boolean`
 - Default: `false`
 
-<iframe style="height: 367px; width: 100%" scrolling="no" frameborder="no" src="/QDatepicker/disabled.html"></iframe>
+<iframe style="height: 150px; width: 100%" scrolling="no" frameborder="no" src="/QDatepicker/disabled.html"></iframe>
+
+### clearable
+
+Shows an icon button, that resets a value.
+
+- Type: `Boolean`
+- Default: `true`
+
+### editable
+
+Whether DatePicker is editable, for type is `date` only.
+
+- Type: `Boolean`
+- Default: `true`
+
+### rangeSeparator
+
+Separator symbol in the middle of the ranged types.
+
+- Type: `String`
+- Default: `'-'`
+
+### disabledValues
+
+- Type: `Object`
+- Default: `null`
+
+The values that should be disabled for choosing. There are three fields:
+- `to` - disable all before this date
+- `from` - disable all after this date
+- `ranges` - array of dateranges, each daterange is object and MUST has `start` and `end` field.
+
+Any field is optional.
+
+```ts
+// import type from lib
+import { QDatePickerPropDisabledValues } from '@qvant/qui-max';
+
+// TS type
+type QDatePickerPropDisabledValues = Nullable<{
+  to?: Date;
+  from?: Date;
+  ranges?: {
+    start: Date;
+    end: Date;
+  }[];
+}>;
+```
+
+```vue {3}
+<q-date-picker
+  v-model="value"
+  :disabled-values="disabledValues"
+/>
+```
+
+```js
+export default defineComponent({
+  setup() {
+    const value = ref(null);
+    const valueRanges = ref(null)
+    // disable values due today
+    const disabledValues = {
+      to: new Date(),
+    }
+    // disable range - tree days in two days from today
+    const disabledValuesRanges = {
+      ranges: [
+        {
+          start: new Date(Date.now() + 48 * 3600 * 1000),
+          end: new Date(Date.now() + 120 * 3600 * 1000)
+        }
+      ]
+    }
+
+    return { value, valueRanges, disabledValues, disabledValuesRanges };
+  }
+})
+```
+
+<iframe style="height: 367px; width: 769px" scrolling="no" frameborder="no" src="/QDatepicker/disabledValues.html"></iframe>
+
+### validateEvent
+
+- type `Boolean`
+- default `false`
+
+If `QDatePicker` wrapped in `QFormItem`, this prop defines if datepicker's input `change` event will be validated immediately
 
 ### name
 
@@ -258,3 +346,40 @@ As native name for input
 
 - Type: `String`
 - Default: `''`
+
+### teleportTo
+
+- Type `String, HTMLElement`
+- Default: `null`
+
+Specifies a target element where QDatePicker will be moved from original layout place. (has to be a valid query selector, or an HTMLElement).
+
+## Events
+
+### update:modelValue
+
+Triggers when model updates.
+
+### change
+
+Alias for update:modelValue.
+
+### focus
+
+Triggers when the QDatePicker gets focus
+
+### input
+
+Triggers when native input event fires
+
+### intermediateChange
+
+Triggers when start date in range picks
+
+- For `daterange`, `monthrange`, `yearrange` types only
+
+## Slots
+
+### range-separator
+
+Set any content as `rangeSeparator` by slot.

--- a/vuepress-docs/docs/components/QDatepicker.md
+++ b/vuepress-docs/docs/components/QDatepicker.md
@@ -55,7 +55,7 @@ Binding value.
 import type { QDatePickerPropModelValue } from '@qvant/qui-max';
 
 // TS type
-type QDatePickerPropModelValue = Nullable<string | Date | string[] | Date[]>;
+type QDatePickerPropModelValue = Nullable<string | Date | [string, string] | [Date, Date]>;
 ```
 
 ### type


### PR DESCRIPTION
docs and some style fixes:

- fix hover in disabled range
before
![Screenshot 2022-02-21 at 13 46 06](https://user-images.githubusercontent.com/14087100/154947628-389d05db-a411-4526-81af-f32d36257b60.png)
after
![Screenshot 2022-02-21 at 14 37 07](https://user-images.githubusercontent.com/14087100/154947908-460c1e2a-d8e2-423d-8819-6626c6e227e0.png)
- fix current day if it is disabled
before
![Screenshot 2022-02-21 at 13 27 30](https://user-images.githubusercontent.com/14087100/154947622-f93fa886-8239-4f94-99b8-02f0691c2da6.png)
after
![Screenshot 2022-02-21 at 13 38 02](https://user-images.githubusercontent.com/14087100/154947843-67f13d25-7450-4847-9188-cd2c45cdb91e.png)
- fix popover position if datepicker inside our Layout (q-row/c-qol)
-before
![Screenshot 2022-02-21 at 14 40 26](https://user-images.githubusercontent.com/14087100/154948476-c995e566-8ea3-49bc-9aec-b827e18ffede.png)


