### PR TITLE
feat: make components treeshakeable

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,6 +18,7 @@ module.exports = {
     if (!config.resolve?.alias) return config;
 
     config.resolve.alias['@'] = path.resolve(__dirname, '../src');
+    config.module.rules.push({ test: /\.scss$/, sideEffects: true });
 
     return config;
   }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "vue-loader": "^15.9.8"
   },
   "files": ["dist"],
+  "sideEffects": false,
   "main": "./dist/qui-max.umd.js",
   "module": "./dist/qui-max.es.js",
   "style": "./dist/style.css",

--- a/src/qComponents/QBreadcrumbs/QBreadcrumbs.test.ts
+++ b/src/qComponents/QBreadcrumbs/QBreadcrumbs.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
-import Component from './index';
+import { QBreadcrumbs } from './index';
 
 describe('QBreadcrumbs', () => {
   it('element should match snapshot', async () => {
-    const { element } = await shallowMount(Component);
+    const { element } = shallowMount(QBreadcrumbs);
 
     expect(element).toMatchSnapshot();
   });

--- a/src/qComponents/QBreadcrumbs/index.ts
+++ b/src/qComponents/QBreadcrumbs/index.ts
@@ -1,17 +1,11 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Breadcrumbs from './src/QBreadcrumbs.vue';
 
-import QBreadcrumbs from './src/QBreadcrumbs.vue';
-
-/* istanbul ignore next */
-QBreadcrumbs.install = (app: App): void => {
-  app.component(QBreadcrumbs.name, QBreadcrumbs);
-};
+export const QBreadcrumbs = /* #__PURE__ */ withInstall(Breadcrumbs);
 
 export type {
   QBreadcrumbsProps,
   QBreadcrumbsPropRoute,
   QBreadcrumbsInstance
 } from './src/types';
-export default QBreadcrumbs as SFCWithInstall<App, typeof QBreadcrumbs>;

--- a/src/qComponents/QBreadcrumbs/src/QBreadcrumbs.vue
+++ b/src/qComponents/QBreadcrumbs/src/QBreadcrumbs.vue
@@ -35,7 +35,7 @@ import type {
   QBreadcrumbsInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QBreadcrumbs',
   componentName: 'QBreadcrumbs',
 

--- a/src/qComponents/QButton/index.ts
+++ b/src/qComponents/QButton/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Button from './src/QButton.vue';
 
-import QButton from './src/QButton.vue';
-
-/* istanbul ignore next */
-QButton.install = (app: App): void => {
-  app.component(QButton.name, QButton);
-};
+export const QButton = /* #__PURE__ */ withInstall(Button);
 
 export type { QButtonProps, QButtonInstance } from './src/types';
-export default QButton as SFCWithInstall<App, typeof QButton>;

--- a/src/qComponents/QButton/src/QButton.vue
+++ b/src/qComponents/QButton/src/QButton.vue
@@ -38,7 +38,7 @@ import type {
   QButtonInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QButton',
   componentName: 'QButton',
 

--- a/src/qComponents/QCascader/index.ts
+++ b/src/qComponents/QCascader/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Cascader from './src/QCascader.vue';
 
-import QCascader from './src/QCascader.vue';
-
-/* istanbul ignore next */
-QCascader.install = (app: App): void => {
-  app.component(QCascader.name, QCascader);
-};
+export const QCascader = /* #__PURE__ */ withInstall(Cascader);
 
 export type { QCascaderProps, QCascaderInstance } from './src/types';
-export default QCascader as SFCWithInstall<App, typeof QCascader>;

--- a/src/qComponents/QCascader/src/QCascader.vue
+++ b/src/qComponents/QCascader/src/QCascader.vue
@@ -60,7 +60,7 @@ import type {
   QCascaderProvider
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCascader',
   componentName: 'QCascader',
 

--- a/src/qComponents/QCascader/src/QCascaderColumn/QCascaderColumn.vue
+++ b/src/qComponents/QCascader/src/QCascaderColumn/QCascaderColumn.vue
@@ -37,7 +37,7 @@ import {
   watch
 } from 'vue';
 
-import QScrollbar from '@/qComponents/QScrollbar';
+import { QScrollbar } from '@/qComponents/QScrollbar';
 import type { Nullable } from '#/helpers';
 
 import findAllLeaves from '../helpers/findAllLeaves';
@@ -54,7 +54,7 @@ import type {
 
 const EXPAND_EVENT = 'expand';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCascaderColumn',
   componentName: 'QCascaderColumn',
 

--- a/src/qComponents/QCascader/src/QCascaderDropdown/QCascaderDropdown.vue
+++ b/src/qComponents/QCascader/src/QCascaderDropdown/QCascaderDropdown.vue
@@ -50,7 +50,7 @@ import type {
 
 const DEFAULT_Z_INDEX = 2000;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCascaderDropdown',
   componentName: 'QCascaderDropdown',
 

--- a/src/qComponents/QCascader/src/QCascaderInput/QCascaderInput.vue
+++ b/src/qComponents/QCascader/src/QCascaderInput/QCascaderInput.vue
@@ -30,7 +30,7 @@ import { defineComponent, inject, computed } from 'vue';
 import { isNumber, isEmpty } from 'lodash-es';
 
 import { t } from '@/qComponents/locale';
-import QInput from '@/qComponents/QInput';
+import { QInput } from '@/qComponents/QInput';
 import type { Nullable } from '#/helpers';
 
 import findFullPath from '../helpers/findFullPath';
@@ -38,7 +38,7 @@ import type { QCascaderProvider } from '../types';
 
 import type { QCascaderInputInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCascaderInput',
   components: { QInput },
   componentName: 'QCascaderInput',

--- a/src/qComponents/QCascader/src/QCascaderRow/QCascaderRow.vue
+++ b/src/qComponents/QCascader/src/QCascaderRow/QCascaderRow.vue
@@ -33,7 +33,7 @@
 <script lang="ts">
 import { defineComponent, inject, computed, PropType } from 'vue';
 
-import QCheckbox from '@/qComponents/QCheckbox';
+import { QCheckbox } from '@/qComponents/QCheckbox';
 import getChildStatuses from '../helpers/getChildStatuses';
 import type { QCascaderProvider } from '../types';
 
@@ -43,7 +43,7 @@ import type {
   QCascaderRowInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCascaderRow',
   components: { QCheckbox },
   componentName: 'QCascaderRow',

--- a/src/qComponents/QCascader/src/QCascaderTags/QCascaderTags.vue
+++ b/src/qComponents/QCascader/src/QCascaderTags/QCascaderTags.vue
@@ -31,13 +31,13 @@
 <script lang="ts">
 import { defineComponent, inject, computed } from 'vue';
 
-import QTag from '@/qComponents/QTag/src/QTag.vue';
+import { QTag } from '@/qComponents/QTag';
 import findFullPath from '../helpers/findFullPath';
 import type { QCascaderProvider } from '../types';
 
 import type { TagItem, QCascaderTagsInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCascaderTags',
   components: { QTag },
   componentName: 'QCascaderTags',

--- a/src/qComponents/QCheckbox/index.ts
+++ b/src/qComponents/QCheckbox/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Checkbox from './src/QCheckbox.vue';
 
-import QCheckbox from './src/QCheckbox.vue';
-
-/* istanbul ignore next */
-QCheckbox.install = (app: App): void => {
-  app.component(QCheckbox.name, QCheckbox);
-};
+export const QCheckbox = /* #__PURE__ */ withInstall(Checkbox);
 
 export type { QCheckboxProps, QCheckboxInstance } from './src/types';
-export default QCheckbox as SFCWithInstall<App, typeof QCheckbox>;

--- a/src/qComponents/QCheckbox/src/QCheckbox.vue
+++ b/src/qComponents/QCheckbox/src/QCheckbox.vue
@@ -59,7 +59,7 @@ import type { Nullable } from '#/helpers';
 
 import type { QCheckboxProps, QCheckboxInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCheckbox',
   componentName: 'QCheckbox',
 

--- a/src/qComponents/QCheckboxGroup/index.ts
+++ b/src/qComponents/QCheckboxGroup/index.ts
@@ -1,17 +1,11 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import CheckboxGroup from './src/QCheckboxGroup.vue';
 
-import QCheckboxGroup from './src/QCheckboxGroup.vue';
-
-/* istanbul ignore next */
-QCheckboxGroup.install = (app: App): void => {
-  app.component(QCheckboxGroup.name, QCheckboxGroup);
-};
+export const QCheckboxGroup = /* #__PURE__ */ withInstall(CheckboxGroup);
 
 export type {
   QCheckboxGroupProps,
   QCheckboxGroupProvider,
   QCheckboxGroupInstance
 } from './src/types';
-export default QCheckboxGroup as SFCWithInstall<App, typeof QCheckboxGroup>;

--- a/src/qComponents/QCheckboxGroup/src/QCheckboxGroup.vue
+++ b/src/qComponents/QCheckboxGroup/src/QCheckboxGroup.vue
@@ -31,7 +31,7 @@ import type {
   QCheckboxGroupInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCheckboxGroup',
   componentName: 'QCheckboxGroup',
 

--- a/src/qComponents/QCol/index.ts
+++ b/src/qComponents/QCol/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Col from './src/QCol.vue';
 
-import QCol from './src/QCol.vue';
-
-/* istanbul ignore next */
-QCol.install = (app: App): void => {
-  app.component(QCol.name, QCol);
-};
+export const QCol = /* #__PURE__ */ withInstall(Col);
 
 export type { QColProps, QColInstance } from './src/types';
-export default QCol as SFCWithInstall<App, typeof QCol>;

--- a/src/qComponents/QCol/src/QCol.vue
+++ b/src/qComponents/QCol/src/QCol.vue
@@ -15,7 +15,7 @@ import type { Nullable } from '#/helpers';
 
 import type { QColProps, QColInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCol',
   componentName: 'QCol',
 

--- a/src/qComponents/QCollapse/index.ts
+++ b/src/qComponents/QCollapse/index.ts
@@ -1,17 +1,11 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Collapse from './src/QCollapse.vue';
 
-import QCollapse from './src/QCollapse.vue';
-
-/* istanbul ignore next */
-QCollapse.install = (app: App): void => {
-  app.component(QCollapse.name, QCollapse);
-};
+export const QCollapse = /* #__PURE__ */ withInstall(Collapse);
 
 export type {
   QCollapseProps,
   QCollapseProvider,
   QCollapseInstance
 } from './src/types';
-export default QCollapse as SFCWithInstall<App, typeof QCollapse>;

--- a/src/qComponents/QCollapse/src/QCollapse.vue
+++ b/src/qComponents/QCollapse/src/QCollapse.vue
@@ -15,7 +15,7 @@ import type {
   QCollapseInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCollapse',
   componentName: 'QCollapse',
 

--- a/src/qComponents/QCollapseItem/index.ts
+++ b/src/qComponents/QCollapseItem/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import CollapseItem from './src/QCollapseItem.vue';
 
-import QCollapseItem from './src/QCollapseItem.vue';
-
-/* istanbul ignore next */
-QCollapseItem.install = (app: App): void => {
-  app.component(QCollapseItem.name, QCollapseItem);
-};
+export const QCollapseItem = /* #__PURE__ */ withInstall(CollapseItem);
 
 export type { QCollapseItemProps, QCollapseItemInstance } from './src/types';
-export default QCollapseItem as SFCWithInstall<App, typeof QCollapseItem>;

--- a/src/qComponents/QCollapseItem/src/QCollapseItem.vue
+++ b/src/qComponents/QCollapseItem/src/QCollapseItem.vue
@@ -40,7 +40,7 @@ import type { QCollapseProvider } from '@/qComponents/QCollapse';
 import QCollapseTransition from './QCollapseTransition.vue';
 import type { QCollapseItemProps, QCollapseItemInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCollapseItem',
   componentName: 'QCollapseItem',
 

--- a/src/qComponents/QCollapseItem/src/QCollapseTransition.vue
+++ b/src/qComponents/QCollapseItem/src/QCollapseTransition.vue
@@ -71,7 +71,7 @@ const on = {
 };
 /* eslint-enable no-param-reassign */
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QCollapseTransition',
 
   setup(): QCollapseTransitionInstance {

--- a/src/qComponents/QColorPicker/index.ts
+++ b/src/qComponents/QColorPicker/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import ColorPicker from './src/QColorPicker.vue';
 
-import QColorPicker from './src/QColorPicker.vue';
-
-/* istanbul ignore next */
-QColorPicker.install = (app: App): void => {
-  app.component(QColorPicker.name, QColorPicker);
-};
+export const QColorPicker = /* #__PURE__ */ withInstall(ColorPicker);
 
 export type { QColorPickerProps, QColorPickerInstance } from './src/types';
-export default QColorPicker as SFCWithInstall<App, typeof QColorPicker>;

--- a/src/qComponents/QColorPicker/src/QColorAlphaSlider/QColorAlphaSlider.vue
+++ b/src/qComponents/QColorPicker/src/QColorAlphaSlider/QColorAlphaSlider.vue
@@ -36,7 +36,7 @@ import draggable from '../utils/draggable';
 import type { QPickerDropdownProvider } from '../QPickerDropdown';
 import type { QColorAlphaSliderInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QColorAlphaSlider',
   componentName: 'QColorAlphaSlider',
 

--- a/src/qComponents/QColorPicker/src/QColorHueSlider/QColorHueSlider.vue
+++ b/src/qComponents/QColorPicker/src/QColorHueSlider/QColorHueSlider.vue
@@ -33,7 +33,7 @@ import draggable from '../utils/draggable';
 import type { QPickerDropdownProvider } from '../QPickerDropdown';
 import type { QColorHueSliderInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QColorHueSlider',
   componentName: 'QColorHueSlider',
 

--- a/src/qComponents/QColorPicker/src/QColorPicker.vue
+++ b/src/qComponents/QColorPicker/src/QColorPicker.vue
@@ -87,7 +87,7 @@ import type {
 
 const DEFAULT_Z_INDEX = 2000;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QColorPicker',
   componentName: 'QColorPicker',
 

--- a/src/qComponents/QColorPicker/src/QColorSvpanel/QColorSvpanel.vue
+++ b/src/qComponents/QColorPicker/src/QColorSvpanel/QColorSvpanel.vue
@@ -29,7 +29,7 @@ import draggable from '../utils/draggable';
 import type { QPickerDropdownProvider } from '../QPickerDropdown';
 import type { QColorSvpanelInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QColorSvpanel',
   componentName: 'QColorSvpanel',
 

--- a/src/qComponents/QColorPicker/src/QPickerDropdown/QPickerDropdown.vue
+++ b/src/qComponents/QColorPicker/src/QPickerDropdown/QPickerDropdown.vue
@@ -67,8 +67,8 @@ import type { HsvaColor } from 'colord';
 
 import { t } from '@/qComponents/locale';
 import { validateArray } from '@/qComponents/helpers';
-import QButton from '@/qComponents/QButton';
-import QInput from '@/qComponents/QInput';
+import { QButton } from '@/qComponents/QButton';
+import { QInput } from '@/qComponents/QInput';
 import type { Nillable, Nullable, UnwrappedInstance } from '#/helpers';
 
 import QColorSvpanel from '../QColorSvpanel';
@@ -92,7 +92,7 @@ const DEFAULT_SATURATION = 100;
 const DEFAULT_VALUE = 100;
 const DEFAULT_ALPHA = 100;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QPickerDropdown',
   componentName: 'QPickerDropdown',
 

--- a/src/qComponents/QContextMenu/index.ts
+++ b/src/qComponents/QContextMenu/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import ContextMenu from './src/QContextMenu.vue';
 
-import QContextMenu from './src/QContextMenu.vue';
-
-/* istanbul ignore next */
-QContextMenu.install = (app: App): void => {
-  app.component(QContextMenu.name, QContextMenu);
-};
+export const QContextMenu = /* #__PURE__ */ withInstall(ContextMenu);
 
 export type { QContextMenuProps, QContextMenuInstance } from './src/types';
-export default QContextMenu as SFCWithInstall<App, typeof QContextMenu>;

--- a/src/qComponents/QContextMenu/src/QContextMenu.vue
+++ b/src/qComponents/QContextMenu/src/QContextMenu.vue
@@ -82,7 +82,7 @@ import type {
 
 const DEFAULT_Z_INDEX = 2000;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QContextMenu',
   componentName: 'QContextMenu',
 

--- a/src/qComponents/QDatePicker/index.ts
+++ b/src/qComponents/QDatePicker/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import DatePicker from './src/QDatePicker.vue';
 
-import QDatePicker from './src/QDatePicker.vue';
-
-/* istanbul ignore next */
-QDatePicker.install = (app: App): void => {
-  app.component(QDatePicker.name, QDatePicker);
-};
+export const QDatePicker = /* #__PURE__ */ withInstall(DatePicker);
 
 export type { QDatePickerPropModelValue, QDatePickerProps } from './src/types';
-export default QDatePicker as SFCWithInstall<App, typeof QDatePicker>;

--- a/src/qComponents/QDatePicker/src/QDatePicker.vue
+++ b/src/qComponents/QDatePicker/src/QDatePicker.vue
@@ -125,7 +125,7 @@ import { getConfig } from '@/qComponents/config';
 import { t } from '@/qComponents/locale';
 import { notNull, validateArray } from '@/qComponents/helpers';
 import { useMediaQuery } from '@/qComponents/hooks';
-import QInput from '@/qComponents/QInput';
+import { QInput } from '@/qComponents/QInput';
 import { useDialog } from '@/qComponents/QDialog';
 import type { QFormProvider } from '@/qComponents/QForm';
 import type { QInputInstance } from '@/qComponents/QInput';
@@ -158,7 +158,7 @@ import type {
 } from './types';
 import { QDatePickerPanelComponent } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePicker',
   componentName: 'QDatePicker',
   components: { QInput },

--- a/src/qComponents/QDatePicker/src/mobile/MobilePanel.vue
+++ b/src/qComponents/QDatePicker/src/mobile/MobilePanel.vue
@@ -19,14 +19,14 @@
 <script lang="ts">
 import { defineComponent, inject } from 'vue';
 
-import QButton from '@/qComponents/QButton';
+import { QButton } from '@/qComponents/QButton';
 import { QDialogContent, QDialogAction } from '@/qComponents/QDialog';
 import type { QDialogContainerProvider } from '@/qComponents/QDialog';
 
 import type { QDatePickerPropModelValue, QDatePickerProvider } from '../types';
 import type { MobilePanelInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'MobilePanel',
 
   components: { QDialogContent, QButton },

--- a/src/qComponents/QDatePicker/src/panel/Date/DatePanel.vue
+++ b/src/qComponents/QDatePicker/src/panel/Date/DatePanel.vue
@@ -130,7 +130,7 @@ import type {
   DatePanelState
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePickerPanelDate',
 
   components: {

--- a/src/qComponents/QDatePicker/src/panel/DateRange/DateRange.vue
+++ b/src/qComponents/QDatePicker/src/panel/DateRange/DateRange.vue
@@ -156,7 +156,7 @@ import type {
   DateRangePanelState
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePickerPanelDateRange',
 
   components: {

--- a/src/qComponents/QDatePicker/src/panel/MonthRange/MonthRange.vue
+++ b/src/qComponents/QDatePicker/src/panel/MonthRange/MonthRange.vue
@@ -124,7 +124,7 @@ import type {
   MonthRangeState
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePickerMonthRange',
 
   components: { PeriodTable },

--- a/src/qComponents/QDatePicker/src/panel/YearRange/YearRange.vue
+++ b/src/qComponents/QDatePicker/src/panel/YearRange/YearRange.vue
@@ -124,7 +124,7 @@ import type {
   YearRangeState
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePickerYearRange',
 
   components: { PeriodTable },

--- a/src/qComponents/QDatePicker/src/tables/DateTable/DateTable.vue
+++ b/src/qComponents/QDatePicker/src/tables/DateTable/DateTable.vue
@@ -75,7 +75,7 @@ import checkDisabled from './checkDisabled';
 
 const locales: Record<string, Locale> = { ru, en, zh };
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePickerDateTable',
 
   props: {

--- a/src/qComponents/QDatePicker/src/tables/PeriodTable/PeriodTable.vue
+++ b/src/qComponents/QDatePicker/src/tables/PeriodTable/PeriodTable.vue
@@ -59,7 +59,7 @@ import type {
   PeriodTableState
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDatePickerPeriodTable',
 
   props: {

--- a/src/qComponents/QDialog/src/QDialogContainer/index.vue
+++ b/src/qComponents/QDialog/src/QDialogContainer/index.vue
@@ -60,7 +60,7 @@ import type {
   QDialogContainerProvider
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDialogContainer',
   componentName: 'QDialogContainer',
 

--- a/src/qComponents/QDialog/src/QDialogContent/index.vue
+++ b/src/qComponents/QDialog/src/QDialogContent/index.vue
@@ -31,15 +31,15 @@
 <script lang="ts">
 import { defineComponent, inject } from 'vue';
 
-import QScrollbar from '@/qComponents/QScrollbar';
-import QButton from '@/qComponents/QButton';
+import { QScrollbar } from '@/qComponents/QScrollbar';
+import { QButton } from '@/qComponents/QButton';
 
 import type { Nullable } from '#/helpers';
 
 import type { QDialogContainerProvider } from '../QDialogContainer';
 import type { QDialogContentInstance, QDialogContentProps } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDialogContent',
   componentName: 'QDialogContent',
 

--- a/src/qComponents/QDrawer/src/QDrawerContainer/index.vue
+++ b/src/qComponents/QDrawer/src/QDrawerContainer/index.vue
@@ -69,7 +69,7 @@ import type {
   QDrawerContainerProvider
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDrawerContainer',
   componentName: 'QDrawerContainer',
 

--- a/src/qComponents/QDrawer/src/QDrawerContent/index.vue
+++ b/src/qComponents/QDrawer/src/QDrawerContent/index.vue
@@ -25,14 +25,14 @@
 <script lang="ts">
 import { defineComponent, inject } from 'vue';
 
-import QScrollbar from '@/qComponents/QScrollbar';
+import { QScrollbar } from '@/qComponents/QScrollbar';
 
 import type { Nullable } from '#/helpers';
 
 import type { QDrawerContainerProvider } from '../QDrawerContainer';
 import type { QDrawerContentInstance, QDrawerContentProps } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDrawerContent',
   componentName: 'QDrawerContent',
 

--- a/src/qComponents/QForm/index.ts
+++ b/src/qComponents/QForm/index.ts
@@ -1,13 +1,8 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Form from './src/QForm.vue';
 
-import QForm from './src/QForm.vue';
-
-/* istanbul ignore next */
-QForm.install = (app: App): void => {
-  app.component(QForm.name, QForm);
-};
+export const QForm = /* #__PURE__ */ withInstall(Form);
 
 export type {
   QFormProps,
@@ -16,4 +11,3 @@ export type {
   QFormProvider,
   QFormInstance
 } from './src/types';
-export default QForm as SFCWithInstall<App, typeof QForm>;

--- a/src/qComponents/QForm/src/QForm.vue
+++ b/src/qComponents/QForm/src/QForm.vue
@@ -33,7 +33,7 @@ import type {
  * Form consists of `input`, `radio`, `select`, `checkbox` and so on.
  * With form, you can collect, verify and submit data. You must use QFormItem inside QForm
  */
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QForm',
   componentName: 'QForm',
 

--- a/src/qComponents/QFormItem/index.ts
+++ b/src/qComponents/QFormItem/index.ts
@@ -1,13 +1,8 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import FormItem from './src/QFormItem.vue';
 
-import QFormItem from './src/QFormItem.vue';
-
-/* istanbul ignore next */
-QFormItem.install = (app: App): void => {
-  app.component(QFormItem.name, QFormItem);
-};
+export const QFormItem = /* #__PURE__ */ withInstall(FormItem);
 
 export type {
   QFormItemProps,
@@ -16,4 +11,3 @@ export type {
   QFormItemProvider,
   QFormItemInstance
 } from './src/types';
-export default QFormItem as SFCWithInstall<App, typeof QFormItem>;

--- a/src/qComponents/QFormItem/src/QFormItem.vue
+++ b/src/qComponents/QFormItem/src/QFormItem.vue
@@ -71,7 +71,7 @@ import type {
   QFormItemInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QFormItem',
   componentName: 'QFormItem',
 

--- a/src/qComponents/QInput/index.ts
+++ b/src/qComponents/QInput/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Input from './src/QInput.vue';
 
-import QInput from './src/QInput.vue';
-
-/* istanbul ignore next */
-QInput.install = (app: App): void => {
-  app.component(QInput.name, QInput);
-};
+export const QInput = /* #__PURE__ */ withInstall(Input);
 
 export type { QInputProps, QInputInstance } from './src/types';
-export default QInput as SFCWithInstall<App, typeof QInput>;

--- a/src/qComponents/QInput/src/QInput.vue
+++ b/src/qComponents/QInput/src/QInput.vue
@@ -80,7 +80,7 @@ import type {
   QInputClass
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QInput',
   componentName: 'QInput',
 

--- a/src/qComponents/QInputNumber/index.ts
+++ b/src/qComponents/QInputNumber/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import InputNumber from './src/QInputNumber.vue';
 
-import QInputNumber from './src/QInputNumber.vue';
-
-/* istanbul ignore next */
-QInputNumber.install = (app: App): void => {
-  app.component(QInputNumber.name, QInputNumber);
-};
+export const QInputNumber = /* #__PURE__ */ withInstall(InputNumber);
 
 export type { QInputNumberProps, QInputNumberInstance } from './src/types';
-export default QInputNumber as SFCWithInstall<App, typeof QInputNumber>;

--- a/src/qComponents/QInputNumber/src/QInputNumber.vue
+++ b/src/qComponents/QInputNumber/src/QInputNumber.vue
@@ -43,7 +43,7 @@ import type { QInputNumberInstance, QInputNumberProps } from './types';
 const MIN_INTEGER = Number(String(Number.MIN_SAFE_INTEGER).slice(0, -2));
 const MAX_INTEGER = Number(String(Number.MAX_SAFE_INTEGER).slice(0, -2));
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QInputNumber',
   componentName: 'QInputNumber',
   inheritAttrs: false,

--- a/src/qComponents/QMessageBox/src/QMessageBoxContainer/index.vue
+++ b/src/qComponents/QMessageBox/src/QMessageBoxContainer/index.vue
@@ -59,7 +59,7 @@ import {
 } from 'vue';
 import type { PropType } from 'vue';
 
-import QScrollbar from '@/qComponents/QScrollbar';
+import { QScrollbar } from '@/qComponents/QScrollbar';
 import { isServer } from '@/qComponents/constants/isServer';
 import { getConfig } from '@/qComponents/config';
 
@@ -82,7 +82,7 @@ import type {
   QMessageBoxContainerInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QMessageBoxContainer',
   componentName: 'QMessageBoxContainer',
 

--- a/src/qComponents/QMessageBox/src/QMessageBoxContent/index.vue
+++ b/src/qComponents/QMessageBox/src/QMessageBoxContent/index.vue
@@ -56,7 +56,7 @@
 import { defineComponent, ref, computed, inject } from 'vue';
 import type { PropType } from 'vue';
 
-import QButton from '@/qComponents/QButton';
+import { QButton } from '@/qComponents/QButton';
 
 import { Nullable } from '#/helpers';
 import type { QMessageBoxContainerProvider } from '../QMessageBoxContainer';
@@ -68,7 +68,7 @@ import type {
   QMessageBoxContentInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QMessageBoxContent',
   componentName: 'QMessageBoxContent',
 

--- a/src/qComponents/QNotification/index.ts
+++ b/src/qComponents/QNotification/index.ts
@@ -27,5 +27,10 @@ const useNotify = (options?: QNotificationOptions): QNotify => {
 };
 
 export type { QNotify, QNotifyId } from './src/types';
-export { Q_NOTIFY_INJECTION_KEY, NotifyType, provideNotify, useNotify };
-export default QNotification;
+export {
+  Q_NOTIFY_INJECTION_KEY,
+  NotifyType,
+  QNotification,
+  provideNotify,
+  useNotify
+};

--- a/src/qComponents/QNotification/src/QNotificationContainer/QNotificationContainer.vue
+++ b/src/qComponents/QNotification/src/QNotificationContainer/QNotificationContainer.vue
@@ -30,7 +30,7 @@ import type {
   QNotificationContainerInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QNotificationContainer',
   componentName: 'QNotificationContainer',
 

--- a/src/qComponents/QNotification/src/QNotificationToast/QNotificationToast.vue
+++ b/src/qComponents/QNotification/src/QNotificationToast/QNotificationToast.vue
@@ -43,7 +43,7 @@ import type {
   QNotificationToastInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QNotificationToast',
   componentName: 'QNotificationToast',
 

--- a/src/qComponents/QOption/index.ts
+++ b/src/qComponents/QOption/index.ts
@@ -1,13 +1,8 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Option from './src/QOption.vue';
 
-import QOption from './src/QOption.vue';
-
-/* istanbul ignore next */
-QOption.install = (app: App): void => {
-  app.component(QOption.name, QOption);
-};
+export const QOption = /* #__PURE__ */ withInstall(Option);
 
 export type {
   QOptionInstance,
@@ -15,4 +10,3 @@ export type {
   QOptionModel,
   QOptionProps
 } from './src/types';
-export default QOption as SFCWithInstall<App, typeof QOption>;

--- a/src/qComponents/QOption/src/QOption.vue
+++ b/src/qComponents/QOption/src/QOption.vue
@@ -45,7 +45,7 @@ import {
   onMounted
 } from 'vue';
 
-import QCheckbox from '@/qComponents/QCheckbox';
+import { QCheckbox } from '@/qComponents/QCheckbox';
 import type { QSelectProvider } from '@/qComponents/QSelect';
 import type { Nullable } from '#/helpers';
 
@@ -56,7 +56,7 @@ import type {
   QOptionModel
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QOption',
   componentName: 'QOption',
 

--- a/src/qComponents/QPagination/index.ts
+++ b/src/qComponents/QPagination/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Pagination from './src/QPagination.vue';
 
-import QPagination from './src/QPagination.vue';
-
-/* istanbul ignore next */
-QPagination.install = (app: App): void => {
-  app.component(QPagination.name, QPagination);
-};
+export const QPagination = /* #__PURE__ */ withInstall(Pagination);
 
 export type { QPaginationProps, QPaginationInstance } from './src/types';
-export default QPagination as SFCWithInstall<App, typeof QPagination>;

--- a/src/qComponents/QPagination/src/QPagination.vue
+++ b/src/qComponents/QPagination/src/QPagination.vue
@@ -88,7 +88,7 @@ import { range } from 'lodash-es';
 
 import type { QPaginationProps, QPaginationInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QPagination',
   componentName: 'QPagination',
 

--- a/src/qComponents/QPopover/index.ts
+++ b/src/qComponents/QPopover/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Popover from './src/QPopover.vue';
 
-import QPopover from './src/QPopover.vue';
-
-/* istanbul ignore next */
-QPopover.install = (app: App): void => {
-  app.component(QPopover.name, QPopover);
-};
+export const QPopover = /* #__PURE__ */ withInstall(Popover);
 
 export type { QPopoverProps, QPopoveInstance } from './src/types';
-export default QPopover as SFCWithInstall<App, typeof QPopover>;

--- a/src/qComponents/QPopover/src/QPopover.vue
+++ b/src/qComponents/QPopover/src/QPopover.vue
@@ -78,7 +78,7 @@ import type {
 
 const DEFAULT_Z_INDEX = 2000;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QPopover',
   componentName: 'QPopover',
 

--- a/src/qComponents/QProgressIndicatior/index.ts
+++ b/src/qComponents/QProgressIndicatior/index.ts
@@ -27,6 +27,8 @@ const useProgressIndicatior = (): Nillable<QProgressIndicatior> => {
     : progressIndicatior;
 };
 
-export { useProgressIndicatior };
+export {
+  QProgressIndicatiorPlugin as QProgressIndicatior,
+  useProgressIndicatior
+};
 export type { QProgressIndicatiorPluginOptions };
-export default QProgressIndicatiorPlugin;

--- a/src/qComponents/QProgressIndicatior/src/QProgressIndicatiorContainer/QProgressIndicatiorContainer.vue
+++ b/src/qComponents/QProgressIndicatior/src/QProgressIndicatiorContainer/QProgressIndicatiorContainer.vue
@@ -17,7 +17,7 @@ import type {
   QProgressIndicatiorContainerInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QProgressIndicatiorContainer',
   componentName: 'QProgressIndicatiorContainer',
 

--- a/src/qComponents/QRadio/index.ts
+++ b/src/qComponents/QRadio/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Radio from './src/QRadio.vue';
 
-import QRadio from './src/QRadio.vue';
-
-/* istanbul ignore next */
-QRadio.install = (app: App): void => {
-  app.component(QRadio.name, QRadio);
-};
+export const QRadio = /* #__PURE__ */ withInstall(Radio);
 
 export type { QRadioProps, QRadioInstance } from './src/types';
-export default QRadio as SFCWithInstall<App, typeof QRadio>;

--- a/src/qComponents/QRadio/src/QRadio.vue
+++ b/src/qComponents/QRadio/src/QRadio.vue
@@ -40,7 +40,7 @@ import type { Nullable } from '#/helpers';
 
 import type { QRadioProps, QRadioInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QRadio',
   componentName: 'QRadio',
 

--- a/src/qComponents/QRadioGroup/index.ts
+++ b/src/qComponents/QRadioGroup/index.ts
@@ -1,17 +1,11 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import RadioGroup from './src/QRadioGroup.vue';
 
-import QRadioGroup from './src/QRadioGroup.vue';
-
-/* istanbul ignore next */
-QRadioGroup.install = (app: App): void => {
-  app.component(QRadioGroup.name, QRadioGroup);
-};
+export const QRadioGroup = /* #__PURE__ */ withInstall(RadioGroup);
 
 export type {
   QRadioGroupProps,
   QRadioGroupProvider,
   QRadioGroupInstance
 } from './src/types';
-export default QRadioGroup as SFCWithInstall<App, typeof QRadioGroup>;

--- a/src/qComponents/QRadioGroup/src/QRadioGroup.vue
+++ b/src/qComponents/QRadioGroup/src/QRadioGroup.vue
@@ -35,7 +35,7 @@ import type {
   QRadioGroupInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QRadioGroup',
   componentName: 'QRadioGroup',
 

--- a/src/qComponents/QRow/index.ts
+++ b/src/qComponents/QRow/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Row from './src/QRow.vue';
 
-import QRow from './src/QRow.vue';
-
-/* istanbul ignore next */
-QRow.install = (app: App): void => {
-  app.component(QRow.name, QRow);
-};
+export const QRow = /* #__PURE__ */ withInstall(Row);
 
 export type { QRowProps, QRowInstance } from './src/types';
-export default QRow as SFCWithInstall<App, typeof QRow>;

--- a/src/qComponents/QRow/src/QRow.vue
+++ b/src/qComponents/QRow/src/QRow.vue
@@ -21,7 +21,7 @@ import type {
   QRowInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QRow',
   componentName: 'QRow',
 

--- a/src/qComponents/QScrollbar/index.ts
+++ b/src/qComponents/QScrollbar/index.ts
@@ -1,17 +1,11 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Scrollbar from './src/QScrollbar.vue';
 
-import QScrollbar from './src/QScrollbar.vue';
-
-/* istanbul ignore next */
-QScrollbar.install = (app: App): void => {
-  app.component(QScrollbar.name, QScrollbar);
-};
+export const QScrollbar = /* #__PURE__ */ withInstall(Scrollbar);
 
 export type {
   QScrollbarProps,
   QScrollbarInstance,
   QScrollbarProvider
 } from './src/types';
-export default QScrollbar as SFCWithInstall<App, typeof QScrollbar>;

--- a/src/qComponents/QScrollbar/src/QBar.vue
+++ b/src/qComponents/QScrollbar/src/QBar.vue
@@ -36,7 +36,7 @@ import type {
 } from './types';
 import { renderThumbStyle, BAR_MAP } from './util';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QBar',
   componentName: 'QBar',
 

--- a/src/qComponents/QScrollbar/src/QScrollbar.vue
+++ b/src/qComponents/QScrollbar/src/QScrollbar.vue
@@ -68,7 +68,7 @@ import type {
 
 const OFFSET = -10;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QScrollbar',
   componentName: 'QScrollbar',
 

--- a/src/qComponents/QSelect/index.ts
+++ b/src/qComponents/QSelect/index.ts
@@ -1,12 +1,8 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Select from './src/QSelect.vue';
 
-import QSelect from './src/QSelect.vue';
-
-QSelect.install = (app: App): void => {
-  app.component(QSelect.name, QSelect);
-};
+export const QSelect = /* #__PURE__ */ withInstall(Select);
 
 export type {
   QSelectPropModelValue,
@@ -15,4 +11,3 @@ export type {
   QSelectState,
   QSelectProps
 } from './src/types';
-export default QSelect as SFCWithInstall<App, typeof QSelect>;

--- a/src/qComponents/QSelect/src/QSelect.vue
+++ b/src/qComponents/QSelect/src/QSelect.vue
@@ -136,7 +136,7 @@ import type {
 import QSelectDropdown from './QSelectDropdown.vue';
 import QSelectTags from './QSelectTags.vue';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSelect',
   componentName: 'QSelect',
 

--- a/src/qComponents/QSelect/src/QSelectDropdown.vue
+++ b/src/qComponents/QSelect/src/QSelectDropdown.vue
@@ -66,9 +66,10 @@
 import { get, isPlainObject } from 'lodash-es';
 import { computed, defineComponent, inject, ref, watch } from 'vue';
 
-import QScrollbar, { QScrollbarInstance } from '@/qComponents/QScrollbar';
-import QOption from '@/qComponents/QOption';
-import QCheckbox from '@/qComponents/QCheckbox';
+import { QScrollbar } from '@/qComponents/QScrollbar';
+import type { QScrollbarInstance } from '@/qComponents/QScrollbar';
+import { QOption } from '@/qComponents/QOption';
+import { QCheckbox } from '@/qComponents/QCheckbox';
 import { getConfig } from '@/qComponents/config';
 import type { QSelectProvider } from '@/qComponents/QSelect';
 import type { QOptionPropValue } from '@/qComponents/QOption';
@@ -78,7 +79,7 @@ import type { QSelectDropdownInstance, QSelectDropdownProps } from './types';
 
 const DEFAULT_Z_INDEX = 2000;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSelectDropdown',
   componentName: 'QSelectDropdown',
 

--- a/src/qComponents/QSelect/src/QSelectTags.vue
+++ b/src/qComponents/QSelect/src/QSelectTags.vue
@@ -58,7 +58,7 @@ import type { Nullable } from '#/helpers';
 
 import type { NewOption, QSelectTagsInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSelectTags',
   componentName: 'QSelectTags',
 

--- a/src/qComponents/QSlider/index.ts
+++ b/src/qComponents/QSlider/index.ts
@@ -1,16 +1,11 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Slider from './src/QSlider.vue';
 
-import QSlider from './src/QSlider.vue';
-
-QSlider.install = (app: App): void => {
-  app.component(QSlider.name, QSlider);
-};
+export const QSlider = /* #__PURE__ */ withInstall(Slider);
 
 export type {
   QSliderProps,
   QSliderPropModelValue,
   QSliderPropData
 } from './src/types';
-export default QSlider as SFCWithInstall<App, typeof QSlider>;

--- a/src/qComponents/QSlider/src/QSlider.vue
+++ b/src/qComponents/QSlider/src/QSlider.vue
@@ -68,7 +68,7 @@ import type {
   QSliderInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSlider',
 
   components: {

--- a/src/qComponents/QSlider/src/components/QSliderBar/QSliderBar.vue
+++ b/src/qComponents/QSlider/src/components/QSliderBar/QSliderBar.vue
@@ -16,7 +16,7 @@ import type {
   QSliderBarInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSliderBar',
 
   props: {

--- a/src/qComponents/QSlider/src/components/QSliderButton/QSliderButton.vue
+++ b/src/qComponents/QSlider/src/components/QSliderButton/QSliderButton.vue
@@ -24,7 +24,7 @@ import type {
   QSliderButtonInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSliderButton',
 
   props: {

--- a/src/qComponents/QSlider/src/components/QSliderCaptions/QSliderCaptions.vue
+++ b/src/qComponents/QSlider/src/components/QSliderCaptions/QSliderCaptions.vue
@@ -16,7 +16,7 @@ import type {
   QSliderCaptionsInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QSliderCaptions',
 
   props: {

--- a/src/qComponents/QTabPane/index.ts
+++ b/src/qComponents/QTabPane/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import TabPane from './src/QTabPane.vue';
 
-import QTabPane from './src/QTabPane.vue';
-
-/* istanbul ignore next */
-QTabPane.install = (app: App): void => {
-  app.component(QTabPane.name, QTabPane);
-};
+export const QTabPane = /* #__PURE__ */ withInstall(TabPane);
 
 export type { QTabPaneProps, QTabPaneInstance } from './src/types';
-export default QTabPane as SFCWithInstall<App, typeof QTabPane>;

--- a/src/qComponents/QTabPane/src/QTabPane.vue
+++ b/src/qComponents/QTabPane/src/QTabPane.vue
@@ -27,7 +27,7 @@ import type { Optional } from '#/helpers';
 
 import type { QTabPaneProps, QTabPaneInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTabPane',
   componentName: 'QTabPane',
 

--- a/src/qComponents/QTable/index.ts
+++ b/src/qComponents/QTable/index.ts
@@ -1,13 +1,8 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Table from './src/QTable.vue';
 
-import QTable from './src/QTable.vue';
-
-/* istanbul ignore next */
-QTable.install = (app: App): void => {
-  app.component(QTable.name, QTable);
-};
+export const QTable = /* #__PURE__ */ withInstall(Table);
 
 export type {
   QTableProps,
@@ -16,4 +11,3 @@ export type {
   QTablePropSortBy,
   QTableInstance
 } from './src/types';
-export default QTable as SFCWithInstall<App, typeof QTable>;

--- a/src/qComponents/QTable/src/QTable.vue
+++ b/src/qComponents/QTable/src/QTable.vue
@@ -36,7 +36,7 @@ import type {
   QTableInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTable',
   componentName: ' QTable',
 

--- a/src/qComponents/QTable/src/QTableCellCheckbox/QTableCellCheckbox.vue
+++ b/src/qComponents/QTable/src/QTableCellCheckbox/QTableCellCheckbox.vue
@@ -21,7 +21,7 @@ import type {
   QTableCellCheckboxInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableCellCheckbox',
   componentName: ' QTableCellCheckbox',
 

--- a/src/qComponents/QTable/src/QTableContainer/QTableContainer.vue
+++ b/src/qComponents/QTable/src/QTableContainer/QTableContainer.vue
@@ -28,7 +28,7 @@ import type {
   ExtendedColumn
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableContainer',
   componentName: ' QTableContainer',
 

--- a/src/qComponents/QTable/src/QTableEmpty/QTableEmpty.vue
+++ b/src/qComponents/QTable/src/QTableEmpty/QTableEmpty.vue
@@ -23,7 +23,7 @@ import { t } from '@/qComponents/locale';
 import image from '@/assets/empty-table-v2.svg';
 import type { QTableEmptyProps, QTableEmptyInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableEmpty',
   componentName: ' QTableEmpty',
 

--- a/src/qComponents/QTable/src/QTableT/QTableT.vue
+++ b/src/qComponents/QTable/src/QTableT/QTableT.vue
@@ -45,7 +45,7 @@ import type { QTableTProvider, QTableTInstance } from './types';
 
 const CHANGE_WIDTH_EVENT = 'change-width';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableT',
   componentName: ' QTableT',
 

--- a/src/qComponents/QTable/src/QTableTBody/QTableTBody.vue
+++ b/src/qComponents/QTable/src/QTableTBody/QTableTBody.vue
@@ -20,7 +20,7 @@ import type { QTableProvider } from '../types';
 import QTableTBodyRow from './QTableTBodyRow/QTableTBodyRow.vue';
 import type { QTableTBodyInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTBody',
   componentName: ' QTableTBody',
 

--- a/src/qComponents/QTable/src/QTableTBody/QTableTBodyCell/QTableTBodyCell.vue
+++ b/src/qComponents/QTable/src/QTableTBody/QTableTBodyCell/QTableTBodyCell.vue
@@ -16,7 +16,7 @@ import type {
   QTableTBodyCellInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTBodyCell',
   componentName: ' QTableTBodyCell',
 

--- a/src/qComponents/QTable/src/QTableTBody/QTableTBodyRow/QTableTBodyRow.vue
+++ b/src/qComponents/QTable/src/QTableTBody/QTableTBodyRow/QTableTBodyRow.vue
@@ -46,7 +46,7 @@ import type {
   RootStyles
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTBodyRow',
   componentName: ' QTableTBodyRow',
 

--- a/src/qComponents/QTable/src/QTableTColgroup/QTableTColgroup.vue
+++ b/src/qComponents/QTable/src/QTableTColgroup/QTableTColgroup.vue
@@ -24,7 +24,7 @@ import type {
 
 import type { QTableTColgroupInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTColgroup',
   componentName: ' QTableTColgroup',
 

--- a/src/qComponents/QTable/src/QTableTHead/QTableTHead.vue
+++ b/src/qComponents/QTable/src/QTableTHead/QTableTHead.vue
@@ -39,7 +39,7 @@ import type {
 import QTableTHeadCell from './QTableTHeadCell/QTableTHeadCell.vue';
 import type { QTableTHeadInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTHead',
   componentName: ' QTableTHead',
 

--- a/src/qComponents/QTable/src/QTableTHead/QTableTHeadCell/QTableTHeadCell.vue
+++ b/src/qComponents/QTable/src/QTableTHead/QTableTHeadCell/QTableTHeadCell.vue
@@ -24,7 +24,7 @@ import type {
   QTableTHeadCellInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTHeadCell',
   componentName: ' QTableTHeadCell',
 

--- a/src/qComponents/QTable/src/QTableTSticky/QTableTSticky.vue
+++ b/src/qComponents/QTable/src/QTableTSticky/QTableTSticky.vue
@@ -37,7 +37,7 @@ import type { StickyGlobalConfig, QTableTStickyInstance } from './types';
 
 const WRAPPER_PADDING_LEFT = 32;
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTSticky',
   componentName: ' QTableTSticky',
 

--- a/src/qComponents/QTable/src/QTableTTotal/QTableTTotal.vue
+++ b/src/qComponents/QTable/src/QTableTTotal/QTableTTotal.vue
@@ -32,7 +32,7 @@ import type {
 import QTableTTotalCell from './QTableTTotalCell/QTableTTotalCell.vue';
 import type { QTableTTotalInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTTotal',
   componentName: ' QTableTTotal',
 

--- a/src/qComponents/QTable/src/QTableTTotal/QTableTTotalCell/QTableTTotalCell.vue
+++ b/src/qComponents/QTable/src/QTableTTotal/QTableTTotalCell/QTableTTotalCell.vue
@@ -11,7 +11,7 @@ import type { ExtendedColumn } from '../../QTableContainer/types';
 
 import type { QTableTTotalCellProps, QTableTTotalCellInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTableTTotalCell',
   componentName: ' QTableTTotalCell',
 

--- a/src/qComponents/QTabs/index.ts
+++ b/src/qComponents/QTabs/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Tabs from './src/QTabs.vue';
 
-import QTabs from './src/QTabs.vue';
-
-/* istanbul ignore next */
-QTabs.install = (app: App): void => {
-  app.component(QTabs.name, QTabs);
-};
+export const QTabs = /* #__PURE__ */ withInstall(Tabs);
 
 export type { QTabsProps, QTabsProvider, QTabsInstance } from './src/types';
-export default QTabs as SFCWithInstall<App, typeof QTabs>;

--- a/src/qComponents/QTabs/src/QTabs.vue
+++ b/src/qComponents/QTabs/src/QTabs.vue
@@ -14,7 +14,7 @@ import type {
   QTabsInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTabs',
   componentName: 'QTabs',
 

--- a/src/qComponents/QTag/index.ts
+++ b/src/qComponents/QTag/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Tag from './src/QTag.vue';
 
-import QTag from './src/QTag.vue';
-
-/* istanbul ignore next */
-QTag.install = (app: App): void => {
-  app.component(QTag.name, QTag);
-};
+export const QTag = /* #__PURE__ */ withInstall(Tag);
 
 export type { QTagProps, QTagInstance } from './src/types';
-export default QTag as SFCWithInstall<App, typeof QTag>;

--- a/src/qComponents/QTag/src/QTag.vue
+++ b/src/qComponents/QTag/src/QTag.vue
@@ -23,7 +23,7 @@ import { defineComponent } from 'vue';
 
 import type { QTagProps, QTagInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTag',
   componentName: 'QTag',
 

--- a/src/qComponents/QTextarea/index.ts
+++ b/src/qComponents/QTextarea/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Textarea from './src/QTextarea.vue';
 
-import QTextarea from './src/QTextarea.vue';
-
-/* istanbul ignore next */
-QTextarea.install = (app: App): void => {
-  app.component(QTextarea.name, QTextarea);
-};
+export const QTextarea = /* #__PURE__ */ withInstall(Textarea);
 
 export type { QTextareaProps, QTextareaInstance } from './src/types';
-export default QTextarea as SFCWithInstall<App, typeof QTextarea>;

--- a/src/qComponents/QTextarea/src/QTextarea.vue
+++ b/src/qComponents/QTextarea/src/QTextarea.vue
@@ -51,7 +51,7 @@ import type {
   QTextareaInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QTextarea',
   componentName: 'QTextarea',
 

--- a/src/qComponents/QUpload/index.ts
+++ b/src/qComponents/QUpload/index.ts
@@ -1,13 +1,7 @@
-import type { App } from 'vue';
+import { withInstall } from '../helpers';
 
-import type { SFCWithInstall } from '#/helpers';
+import Upload from './src/QUpload.vue';
 
-import QUpload from './src/QUpload.vue';
-
-/* istanbul ignore next */
-QUpload.install = (app: App): void => {
-  app.component(QUpload.name, QUpload);
-};
+export const QUpload = /* #__PURE__ */ withInstall(Upload);
 
 export type { QUploadProps, QUploadFile, QUploadInstance } from './src/types';
-export default QUpload as SFCWithInstall<App, typeof QUpload>;

--- a/src/qComponents/QUpload/src/QUpload.vue
+++ b/src/qComponents/QUpload/src/QUpload.vue
@@ -67,7 +67,7 @@ import type {
   QUploadInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QUpload',
   componentName: 'QUpload',
 

--- a/src/qComponents/QUpload/src/QUploadDropZone/QUploadDropZone.vue
+++ b/src/qComponents/QUpload/src/QUploadDropZone/QUploadDropZone.vue
@@ -22,7 +22,7 @@ import { defineComponent, ref, computed } from 'vue';
 import { t } from '@/qComponents/locale';
 import type { QUploadDropZoneProps, QUploadDropZoneInstance } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QUploadDropZone',
   componentName: 'QUploadDropZone',
 

--- a/src/qComponents/QUpload/src/QUploadFileMultiple/QUploadFileMultiple.vue
+++ b/src/qComponents/QUpload/src/QUploadFileMultiple/QUploadFileMultiple.vue
@@ -92,7 +92,7 @@ import type {
   QUploadFileMultipleInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QUploadFileMultiple',
   componentName: 'QUploadFileMultiple',
 

--- a/src/qComponents/QUpload/src/QUploadFileSingle/QUploadFileSingle.vue
+++ b/src/qComponents/QUpload/src/QUploadFileSingle/QUploadFileSingle.vue
@@ -40,7 +40,7 @@ import type {
   QUploadFileSingleInstance
 } from './types';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QUploadFileSingle',
   componentName: 'QUploadFileSingle',
 

--- a/src/qComponents/helpers/index.ts
+++ b/src/qComponents/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './randId';
 export * from './validateArray';
 export * from './notNull';
+export * from './withInstall';

--- a/src/qComponents/helpers/withInstall.ts
+++ b/src/qComponents/helpers/withInstall.ts
@@ -1,0 +1,11 @@
+import type { App, Component } from 'vue';
+import type { SFCWithInstall } from '#/helpers';
+
+export const withInstall = <T extends Component>(
+  main: T
+): SFCWithInstall<T> => ({
+  ...main,
+  install: (app: App): void => {
+    app.component(main.name ?? 'Unknown', main);
+  }
+});

--- a/src/qComponents/index.ts
+++ b/src/qComponents/index.ts
@@ -10,38 +10,38 @@ import {
   ru as localeRu,
   zh as localeZh
 } from './constants/locales';
-import QBreadcrumbs from './QBreadcrumbs';
-import QButton from './QButton';
-import QCascader from './QCascader';
-import QCheckbox from './QCheckbox';
-import QCheckboxGroup from './QCheckboxGroup';
-import QCol from './QCol';
-import QCollapse from './QCollapse';
-import QCollapseItem from './QCollapseItem';
-import QColorPicker from './QColorPicker';
-import QContextMenu from './QContextMenu';
-import QDatePicker from './QDatePicker';
-import QForm from './QForm';
-import QFormItem from './QFormItem';
-import QInput from './QInput';
-import QInputNumber from './QInputNumber';
-import QNotification from './QNotification';
-import QOption from './QOption';
-import QPagination from './QPagination';
-import QPopover from './QPopover';
-import QProgressIndicatior from './QProgressIndicatior';
-import QRadio from './QRadio';
-import QRadioGroup from './QRadioGroup';
-import QRow from './QRow';
-import QScrollbar from './QScrollbar';
-import QSelect from './QSelect';
-import QSlider from './QSlider';
-import QTable from './QTable';
-import QTabPane from './QTabPane';
-import QTabs from './QTabs';
-import QTag from './QTag';
-import QTextarea from './QTextarea';
-import QUpload from './QUpload';
+import { QBreadcrumbs } from './QBreadcrumbs';
+import { QButton } from './QButton';
+import { QCascader } from './QCascader';
+import { QCheckbox } from './QCheckbox';
+import { QCheckboxGroup } from './QCheckboxGroup';
+import { QCol } from './QCol';
+import { QCollapse } from './QCollapse';
+import { QCollapseItem } from './QCollapseItem';
+import { QColorPicker } from './QColorPicker';
+import { QContextMenu } from './QContextMenu';
+import { QDatePicker } from './QDatePicker';
+import { QForm } from './QForm';
+import { QFormItem } from './QFormItem';
+import { QInput } from './QInput';
+import { QInputNumber } from './QInputNumber';
+import { QNotification } from './QNotification';
+import { QOption } from './QOption';
+import { QPagination } from './QPagination';
+import { QPopover } from './QPopover';
+import { QProgressIndicatior } from './QProgressIndicatior';
+import { QRadio } from './QRadio';
+import { QRadioGroup } from './QRadioGroup';
+import { QRow } from './QRow';
+import { QScrollbar } from './QScrollbar';
+import { QSelect } from './QSelect';
+import { QSlider } from './QSlider';
+import { QTable } from './QTable';
+import { QTabPane } from './QTabPane';
+import { QTabs } from './QTabs';
+import { QTag } from './QTag';
+import { QTextarea } from './QTextarea';
+import { QUpload } from './QUpload';
 
 import type { ConfigOptions } from './types';
 
@@ -153,46 +153,7 @@ const install = (app: App, config?: ConfigOptions): void => {
 };
 
 export default { install };
-export {
-  createQui,
-  setMessages,
-  setI18n,
-  QBreadcrumbs,
-  QButton,
-  QCascader,
-  QCheckbox,
-  QCheckboxGroup,
-  QCol,
-  QCollapse,
-  QCollapseItem,
-  QColorPicker,
-  QContextMenu,
-  QDatePicker,
-  QForm,
-  QFormItem,
-  QInput,
-  QInputNumber,
-  QNotification,
-  QOption,
-  QPagination,
-  QPopover,
-  QProgressIndicatior,
-  QRadio,
-  QRadioGroup,
-  QRow,
-  QScrollbar,
-  QSelect,
-  QSlider,
-  QTable,
-  QTabPane,
-  QTabs,
-  QTag,
-  QTextarea,
-  QUpload,
-  localeEn,
-  localeRu,
-  localeZh
-};
+export { createQui, setMessages, setI18n, localeEn, localeRu, localeZh };
 
 export * from './QBreadcrumbs';
 export * from './QButton';

--- a/src/qComponents/locale/index.ts
+++ b/src/qComponents/locale/index.ts
@@ -27,5 +27,3 @@ export const setI18n = (fn: (...args: unknown[]) => string): void => {
 export const setMessages = (messages?: Messages): void => {
   if (messages) currentMessages = messages;
 };
-
-export default { setMessages, t, setI18n };

--- a/stories/Layout/Layout.stories.ts
+++ b/stories/Layout/Layout.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, computed } from 'vue';
 
-import QCol from '@/qComponents/QCol';
-import QRow from '@/qComponents/QRow';
+import { QCol } from '@/qComponents/QCol';
+import { QRow } from '@/qComponents/QRow';
 import './layout.scss';
 
 const storyMetadata: Meta = {

--- a/stories/Layout/QCol.stories.ts
+++ b/stories/Layout/QCol.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent } from 'vue';
 
-import QRow from '@/qComponents/QRow';
-import QCol from '@/qComponents/QCol';
+import { QRow } from '@/qComponents/QRow';
+import { QCol } from '@/qComponents/QCol';
 import type { QColProps } from '@/qComponents/QCol';
 import './layout.scss';
 

--- a/stories/Layout/QRow.stories.ts
+++ b/stories/Layout/QRow.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent } from 'vue';
 
-import QRow from '@/qComponents/QRow';
-import QCol from '@/qComponents/QCol';
+import { QRow } from '@/qComponents/QRow';
+import { QCol } from '@/qComponents/QCol';
 import type { QRowProps } from '@/qComponents/QRow';
 import './layout.scss';
 

--- a/stories/components/QBreadcrumbs.stories.ts
+++ b/stories/components/QBreadcrumbs.stories.ts
@@ -4,7 +4,7 @@ import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, computed } from 'vue';
 import { t } from '@/qComponents/locale';
 
-import QBreadcrumbs from '@/qComponents/QBreadcrumbs';
+import { QBreadcrumbs } from '@/qComponents/QBreadcrumbs';
 import type {
   QBreadcrumbsProps,
   QBreadcrumbsPropRoute

--- a/stories/components/QButton.stories.ts
+++ b/stories/components/QButton.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent } from 'vue';
 
-import QButton from '@/qComponents/QButton';
+import { QButton } from '@/qComponents/QButton';
 import type { QButtonProps } from '@/qComponents/QButton';
 
 const storyMetadata: Meta = {

--- a/stories/components/QCascader.stories.ts
+++ b/stories/components/QCascader.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QCascader from '@/qComponents/QCascader';
+import { QCascader } from '@/qComponents/QCascader';
 import type { QCascaderProps } from '@/qComponents/QCascader';
 
 const storyMetadata: Meta = {

--- a/stories/components/QCheckbox.stories.ts
+++ b/stories/components/QCheckbox.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QCheckbox from '@/qComponents/QCheckbox';
+import { QCheckbox } from '@/qComponents/QCheckbox';
 import type { QCheckboxProps } from '@/qComponents/QCheckbox';
 
 const storyMetadata: Meta = {

--- a/stories/components/QCheckboxGroup/Default.stories.ts
+++ b/stories/components/QCheckboxGroup/Default.stories.ts
@@ -1,8 +1,8 @@
 import type { Story, Meta } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QCheckboxGroup from '@/qComponents/QCheckboxGroup';
-import QCheckbox from '@/qComponents/QCheckbox';
+import { QCheckbox } from '@/qComponents/QCheckbox';
+import { QCheckboxGroup } from '@/qComponents/QCheckboxGroup';
 import type { QCheckboxGroupProps } from '@/qComponents/QCheckboxGroup';
 
 const storyMetadata: Meta = {

--- a/stories/components/QCheckboxGroup/Indeterminate.stories.ts
+++ b/stories/components/QCheckboxGroup/Indeterminate.stories.ts
@@ -1,8 +1,8 @@
 import type { Story, Meta } from '@storybook/vue3';
 import { defineComponent, ref, watch } from 'vue';
 
-import QCheckboxGroup from '@/qComponents/QCheckboxGroup';
-import QCheckbox from '@/qComponents/QCheckbox';
+import { QCheckbox } from '@/qComponents/QCheckbox';
+import { QCheckboxGroup } from '@/qComponents/QCheckboxGroup';
 import type { QCheckboxGroupProps } from '@/qComponents/QCheckboxGroup';
 
 const storyMetadata: Meta = {

--- a/stories/components/QCollapse.stories.ts
+++ b/stories/components/QCollapse.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QCollapse from '@/qComponents/QCollapse';
-import QCollapseItem from '@/qComponents/QCollapseItem';
+import { QCollapse } from '@/qComponents/QCollapse';
+import { QCollapseItem } from '@/qComponents/QCollapseItem';
 import type { QCollapseProps } from '@/qComponents/QCollapse';
 
 const storyMetadata: Meta = {

--- a/stories/components/QColorPicker.stories.ts
+++ b/stories/components/QColorPicker.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 import { placements } from '@popperjs/core/lib/enums';
 
-import QColorPicker from '@/qComponents/QColorPicker';
+import { QColorPicker } from '@/qComponents/QColorPicker';
 import type { QColorPickerProps } from '@/qComponents/QColorPicker';
 
 const storyMetadata: Meta = {

--- a/stories/components/QContextMenu.stories.ts
+++ b/stories/components/QContextMenu.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent } from 'vue';
 
-import QContextMenu from '@/qComponents/QContextMenu';
+import { QContextMenu } from '@/qComponents/QContextMenu';
 import type { QContextMenuProps } from '@/qComponents/QContextMenu';
 
 const storyMetadata: Meta = {

--- a/stories/components/QDatePicker.stories.ts
+++ b/stories/components/QDatePicker.stories.ts
@@ -2,7 +2,7 @@ import { defineComponent, reactive, watch } from 'vue';
 import type { Meta, Story } from '@storybook/vue3';
 import { addMonths, startOfYesterday, subMonths, subWeeks } from 'date-fns';
 
-import QDatePicker from '@/qComponents/QDatePicker';
+import { QDatePicker } from '@/qComponents/QDatePicker';
 import type {
   QDatePickerPropModelValue,
   QDatePickerProps

--- a/stories/components/QForm.stories.ts
+++ b/stories/components/QForm.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, reactive, ref } from 'vue';
 
-import QForm from '@/qComponents/QForm';
-import QFormItem from '@/qComponents/QFormItem';
+import { QForm } from '@/qComponents/QForm';
+import { QFormItem } from '@/qComponents/QFormItem';
 import type {
   QFormProps,
   QFormPropRules,

--- a/stories/components/QInput.stories.ts
+++ b/stories/components/QInput.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QInput from '@/qComponents/QInput';
+import { QInput } from '@/qComponents/QInput';
 import type { QInputProps } from '@/qComponents/QInput';
 import iconsList from '../core/iconsList';
 

--- a/stories/components/QInputNumber.stories.ts
+++ b/stories/components/QInputNumber.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QInputNumber from '@/qComponents/QInputNumber';
+import { QInputNumber } from '@/qComponents/QInputNumber';
 import type { QInputNumberProps } from '@/qComponents/QInputNumber';
 
 const storyMetadata: Meta = {

--- a/stories/components/QPagination.stories.ts
+++ b/stories/components/QPagination.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QPagination from '@/qComponents/QPagination';
+import { QPagination } from '@/qComponents/QPagination';
 import type { QPaginationProps } from '@/qComponents/QPagination';
 
 const storyMetadata: Meta = {

--- a/stories/components/QPopover.stories.ts
+++ b/stories/components/QPopover.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent } from 'vue';
 import { placements } from '@popperjs/core/lib/enums';
 
-import QPopover from '@/qComponents/QPopover';
+import { QPopover } from '@/qComponents/QPopover';
 import type { QPopoverProps } from '@/qComponents/QPopover';
 
 import iconsList from '../core/iconsList';

--- a/stories/components/QRadio.stories.ts
+++ b/stories/components/QRadio.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QRadio from '@/qComponents/QRadio';
+import { QRadio } from '@/qComponents/QRadio';
 import type { QRadioProps } from '@/qComponents/QRadio';
 
 const storyMetadata: Meta = {

--- a/stories/components/QRadioGroup.stories.ts
+++ b/stories/components/QRadioGroup.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QRadioGroup from '@/qComponents/QRadioGroup';
-import QRadio from '@/qComponents/QRadio';
+import { QRadio } from '@/qComponents/QRadio';
+import { QRadioGroup } from '@/qComponents/QRadioGroup';
 import type { QRadioGroupProps } from '@/qComponents/QRadioGroup';
 
 const storyMetadata: Meta = {

--- a/stories/components/QScrollbar/QScrollbar.stories.ts
+++ b/stories/components/QScrollbar/QScrollbar.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent } from 'vue';
 
-import QScrollbar from '@/qComponents/QScrollbar';
+import { QScrollbar } from '@/qComponents/QScrollbar';
 import type { QScrollbarProps } from '@/qComponents/QScrollbar';
 
 import './q-scrollbar.scss';

--- a/stories/components/QSelect.stories.ts
+++ b/stories/components/QSelect.stories.ts
@@ -1,8 +1,8 @@
 import { defineComponent, watch, reactive } from 'vue';
 import type { Meta, Story } from '@storybook/vue3';
 
-import QSelect from '@/qComponents/QSelect';
-import QOption from '@/qComponents/QOption';
+import { QSelect } from '@/qComponents/QSelect';
+import { QOption } from '@/qComponents/QOption';
 import type { QSelectProps } from '@/qComponents/QSelect';
 
 const storyMetadata: Meta = {

--- a/stories/components/QSlider/QSlider.stories.ts
+++ b/stories/components/QSlider/QSlider.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/vue3';
 
-import QSlider from '@/qComponents/QSlider';
+import { QSlider } from '@/qComponents/QSlider';
 
 import Default from './Default';
 import SlotCaption from './SlotCaption';

--- a/stories/components/QTabPane.stories.ts
+++ b/stories/components/QTabPane.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QTabPane from '@/qComponents/QTabPane';
-import QTabs from '@/qComponents/QTabs';
+import { QTabs } from '@/qComponents/QTabs';
+import { QTabPane } from '@/qComponents/QTabPane';
 import type { QTabPaneProps } from '@/qComponents/QTabPane';
 
 const storyMetadata: Meta = {

--- a/stories/components/QTable/QTable.stories.ts
+++ b/stories/components/QTable/QTable.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/vue3';
 
-import QTable from '@/qComponents/QTable';
+import { QTable } from '@/qComponents/QTable';
 
 import Default from './Default';
 import CustomWidth from './CustomWidth';

--- a/stories/components/QTabs.stories.ts
+++ b/stories/components/QTabs.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QTabs from '@/qComponents/QTabs';
-import QTabPane from '@/qComponents/QTabPane';
+import { QTabs } from '@/qComponents/QTabs';
+import { QTabPane } from '@/qComponents/QTabPane';
 import type { QTabsProps } from '@/qComponents/QTabs';
 
 const storyMetadata: Meta = {

--- a/stories/components/QTag.stories.ts
+++ b/stories/components/QTag.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QTag from '@/qComponents/QTag';
+import { QTag } from '@/qComponents/QTag';
 import type { QTagProps } from '@/qComponents/QTag';
 
 const storyMetadata: Meta = {

--- a/stories/components/QTextarea.stories.ts
+++ b/stories/components/QTextarea.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/vue3';
 import { defineComponent, ref } from 'vue';
 
-import QTextarea from '@/qComponents/QTextarea';
+import { QTextarea } from '@/qComponents/QTextarea';
 import type { QTextareaProps } from '@/qComponents/QTextarea';
 
 const storyMetadata: Meta = {

--- a/stories/components/QUpload/Default.stories.ts
+++ b/stories/components/QUpload/Default.stories.ts
@@ -1,8 +1,8 @@
 import type { Story, Meta } from '@storybook/vue3';
 import { defineComponent, reactive } from 'vue';
 
+import { QUpload } from '@/qComponents/QUpload';
 import type { QUploadProps, QUploadFile } from '@/qComponents/QUpload';
-import QUpload from '@/qComponents/QUpload';
 import type { Nullable } from '#/helpers';
 
 interface FormModelFile extends QUploadFile {

--- a/stories/components/QUpload/Multiple.stories.ts
+++ b/stories/components/QUpload/Multiple.stories.ts
@@ -1,8 +1,8 @@
 import type { Story, Meta } from '@storybook/vue3';
 import { defineComponent, reactive } from 'vue';
 
+import { QUpload } from '@/qComponents/QUpload';
 import type { QUploadProps, QUploadFile } from '@/qComponents/QUpload';
-import QUpload from '@/qComponents/QUpload';
 
 interface FormModelFile extends QUploadFile {
   sourceFile: File;

--- a/stories/plugins/QDialog/DialogFormTest.vue
+++ b/stories/plugins/QDialog/DialogFormTest.vue
@@ -41,7 +41,7 @@ import { defineComponent, ref, reactive, inject } from 'vue';
 import { QDialogAction, QDialogContent } from '@/qComponents';
 import type { QDialogContainerProvider } from '@/qComponents';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'DialogFormTest',
 
   components: { QDialogContent },

--- a/stories/plugins/QDrawer/DrawerFormTest.vue
+++ b/stories/plugins/QDrawer/DrawerFormTest.vue
@@ -41,7 +41,7 @@ import { defineComponent, ref, reactive, inject } from 'vue';
 import { QDrawerContent, QDrawerAction } from '@/qComponents';
 import type { QDrawerContainerProvider } from '@/qComponents';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'QDrawerSampleContent',
 
   components: { QDrawerContent },

--- a/stories/plugins/QMessageBox/MessageBoxFormTest.vue
+++ b/stories/plugins/QMessageBox/MessageBoxFormTest.vue
@@ -45,7 +45,7 @@ import { defineComponent, ref, reactive, inject } from 'vue';
 import { QMessageBoxContent, QMessageBoxAction } from '@/qComponents';
 import type { QMessageBoxContainerProvider } from '@/qComponents';
 
-export default defineComponent({
+export default /* #__PURE__ */ defineComponent({
   name: 'MessageBoxFormTest',
 
   components: {

--- a/types/helpers.ts
+++ b/types/helpers.ts
@@ -1,9 +1,9 @@
-import type { ComponentPublicInstance, UnwrapRef } from 'vue';
+import type { App, ComponentPublicInstance, UnwrapRef } from 'vue';
 
 export type Nullable<T> = T | null;
 export type Nillable<T> = T | null | undefined;
 export type Optional<T> = T | undefined;
-export type SFCWithInstall<R, T> = T & { install(app: R): void };
+export type SFCWithInstall<T> = T & { install(app: App): void };
 export type UnwrappedInstance<T> = Nullable<
   ComponentPublicInstance<UnwrapRef<T>>
 >;

--- a/vuepress-docs/docs/components/QForm.md
+++ b/vuepress-docs/docs/components/QForm.md
@@ -23,11 +23,11 @@ Using in template:
     <q-form-item label="Name" prop="name">
       <q-input v-model="formModel.name" type="text" />
     </q-form-item>
-  
+
     <q-form-item label="Intro" prop="intro">
       <q-input v-model="formModel.intro" type="text" />
     </q-form-item>
-  
+
     <q-button @click="handleSubmitClick">Create</q-button>
     <q-button @click="handleResetClick" theme="secondary">Reset</q-button>
   </q-form>
@@ -36,7 +36,6 @@ Using in template:
 Using in component instance:
 
 ```js
-
 const model = {
   name: '',
   intro: ''


### PR DESCRIPTION
partially fix #274 and fix #86

For some reason, the code of external packages(date-fns, object-hash and etc) still in final bundle even if you don't use QDatapicker or QTable. I assume this can be possible resolved by marking them as peerDeps, but i doubt that this is the best decision, so this situation requires further separated investigation.