### PR TITLE
fix(QDatePicker): buttons bg-color in safari

### DIFF
--- a/src/qComponents/QDatePicker/src/panel/q-picker-panel.scss
+++ b/src/qComponents/QDatePicker/src/panel/q-picker-panel.scss
@@ -98,6 +98,7 @@
     white-space: nowrap;
     cursor: pointer;
     user-select: none;
+    background-color: transparent;
     border: none;
 
     &:nth-child(2) {

--- a/src/qComponents/QDatePicker/src/tables/period-table.scss
+++ b/src/qComponents/QDatePicker/src/tables/period-table.scss
@@ -15,6 +15,7 @@
     height: 40px;
     font-weight: var(--font-weight-base);
     color: var(--color-primary-blue);
+    background-color: transparent;
     border: none;
     border-radius: var(--border-radius-base);
     box-shadow: var(--box-shadow-secondary);


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/52715445/177263534-fc4d1125-9427-48ff-bd44-6f333ccc66be.jpeg)
![2](https://user-images.githubusercontent.com/52715445/177263541-5de585da-f7d7-4048-a57f-d622d19abdbf.jpeg)
![3](https://user-images.githubusercontent.com/52715445/177263546-f456875c-8cf7-4eb3-ba15-e87189ecd4d9.jpeg)
![4](https://user-images.githubusercontent.com/52715445/177263547-97753302-0cbd-4227-84f4-036472d1f480.jpeg)
![5](https://user-images.githubusercontent.com/52715445/177263551-8f49460d-19c7-44b9-990b-c67a0d6e2604.jpeg)
![6](https://user-images.githubusercontent.com/52715445/177263557-5682841b-f65a-4186-8cdc-4a4bc25491f1.jpeg)
